### PR TITLE
Link to CLA and document min version of tools-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ class configured by applying the YAML files in the `k8s/` directory:
 
 ### Contributing
 
-All contributors must complete a [Contributor License Agreement](https://gist.github.com/bplatz/18bdfab7221fc1b03eb3293c8fe56077).
+All contributors must complete a [Contributor License Agreement](https://cla-assistant.io/fluree/).
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ class configured by applying the YAML files in the `k8s/` directory:
 
 ## Development
 
+### Contributing
+
+All contributors must complete a [Contributor License Agreement](https://gist.github.com/bplatz/18bdfab7221fc1b03eb3293c8fe56077).
+
 ### Prerequisites
 
-1. Install clojure tools-deps
+1. Install clojure tools-deps (version 1.10.1.697 or later).
     1. macOS: `brew install clojure/tools/clojure`
     1. Arch Linux: `pacman -S clojure`
 


### PR DESCRIPTION
Counterpart to https://github.com/fluree/db/pull/2