### PR TITLE
Add new fdb-storage-file-root config property

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -142,14 +142,14 @@
 (comment
 
   ;; Standalone - On Disk
-  (start {:fdb-mode                   "dev"
-          :fdb-group-servers          "myserver@localhost:9790"
-          :fdb-group-this-server      "myserver"
-          :fdb-group-log-directory    "./data/group/"
-          :fdb-storage-file-directory "./data/ledger/"
-          :fdb-consensus-type         "raft"
-          :fdb-api-open               true
-          :fdb-api-port               8090})
+  (start {:fdb-mode                "dev"
+          :fdb-group-servers       "myserver@localhost:9790"
+          :fdb-group-this-server   "myserver"
+          :fdb-group-log-directory "./data/raft"
+          :fdb-storage-file-root   "./data"
+          :fdb-consensus-type      "raft"
+          :fdb-api-open            true
+          :fdb-api-port            8090})
 
   ;; Standalone - In Memory
   (start {:fdb-group-servers     "DEF@localhost:11001"
@@ -170,50 +170,50 @@
 
 
   ;; Three servers
-  (start {:fdb-group-servers          "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
-          :fdb-group-this-server      "ABC"
-          :fdb-group-log-directory    "./data/ABC/raft/"
-          :fdb-storage-file-directory "./data/ABC/"
-          :fdb-api-port               8090})
-  (start {:fdb-group-servers          "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
-          :fdb-group-this-server      "DEF"
-          :fdb-group-log-directory    "./data/DEF/raft/"
-          :fdb-storage-file-directory "./data/DEF/"
-          :fdb-api-port               8091})
+  (start {:fdb-group-servers       "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
+          :fdb-group-this-server   "ABC"
+          :fdb-group-log-directory "./data/ABC/raft/"
+          :fdb-storage-file-root   "./data/ABC/"
+          :fdb-api-port            8090})
+  (start {:fdb-group-servers       "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
+          :fdb-group-this-server   "DEF"
+          :fdb-group-log-directory "./data/DEF/raft/"
+          :fdb-storage-file-root   "./data/DEF/"
+          :fdb-api-port            8091})
 
-  (start {:fdb-group-servers          "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
-          :fdb-group-this-server      "GHI"
-          :fdb-group-log-directory    "./data/GHI/raft/"
-          :fdb-storage-file-directory "./data/GHI/"
-          :fdb-api-port               8092})
+  (start {:fdb-group-servers       "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
+          :fdb-group-this-server   "GHI"
+          :fdb-group-log-directory "./data/GHI/raft/"
+          :fdb-storage-file-root   "./data/GHI/"
+          :fdb-api-port            8092})
 
   ;; Three servers dynamic changes
 
 
   ;; Start first
-  (start {:fdb-group-servers          "ABC@localhost:9790"
-          :fdb-group-this-server      "ABC"
-          :fdb-group-log-directory    "./data/ABC/raft/"
-          :fdb-storage-file-directory "./data/ABC/"
-          :fdb-api-port               8090
-          :fdb-join?                  false})
+  (start {:fdb-group-servers       "ABC@localhost:9790"
+          :fdb-group-this-server   "ABC"
+          :fdb-group-log-directory "./data/ABC/raft/"
+          :fdb-storage-file-root   "./data/ABC/"
+          :fdb-api-port            8090
+          :fdb-join?               false})
 
-  (start {:fdb-group-servers          "ABC@localhost:9790,DEF@localhost:9791"
-          :fdb-group-this-server      "DEF"
-          :fdb-group-log-directory    "./data/DEF/raft/"
-          :fdb-storage-file-directory "./data/DEF/"
-          :fdb-api-port               8091
-          :fdb-join?                  true})
+  (start {:fdb-group-servers       "ABC@localhost:9790,DEF@localhost:9791"
+          :fdb-group-this-server   "DEF"
+          :fdb-group-log-directory "./data/DEF/raft/"
+          :fdb-storage-file-root   "./data/DEF/"
+          :fdb-api-port            8091
+          :fdb-join?               true})
 
   ;; Add server two
   (txproto/-add-server-async (:group system) "DEF")
 
-  (start {:fdb-group-servers          "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
-          :fdb-group-this-server      "GHI"
-          :fdb-group-log-directory    "./data/GHI/raft/"
-          :fdb-storage-file-directory "./data/GHI/"
-          :fdb-api-port               8092
-          :fdb-join?                  true})
+  (start {:fdb-group-servers       "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"
+          :fdb-group-this-server   "GHI"
+          :fdb-group-log-directory "./data/GHI/raft/"
+          :fdb-storage-file-root   "./data/GHI/"
+          :fdb-api-port            8092
+          :fdb-join?               true})
 
   ;; Add/ remove server three
   (txproto/-add-server-async (:group system) "GHI")

--- a/resources/fluree_sample.properties
+++ b/resources/fluree_sample.properties
@@ -85,7 +85,7 @@ fdb-group-snapshot-threshold=200
 # For file storage-type only: The root directory to put relative storage paths in.
 # Can be a relative path starting with "." or an absolute path starting with "/".
 # Defaults to ./data
-#fdb-storage-file-directory=./data
+#fdb-storage-file-root=./data
 
 # For s3 storage-type only: Specify the AWS S3 bucket to store ledger
 # (blockchain), db indexes, and raft snapshots. Make sure to specify the name


### PR DESCRIPTION
...and deprecate fdb-storage-file-directory but still use it in a backwards-compatible way for now.

This should allow starting up a v0.17+ ledger on an older config (presumably with existing ledgers) and it will still work and see the data. It will print a deprecation warning with upgrading instructions.