### PR TITLE
Use self-hosted (on AWS) GitHub Action runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, docker]
     steps:
       - uses: actions/checkout@v2
       - name: Run integration tests
@@ -24,7 +24,7 @@ jobs:
 
   #  debug:
   #    needs: test
-  #    runs-on: self-hosted
+  #    runs-on: [self-hosted, docker]
   #    steps:
   #      - run: echo "$GITHUB_CONTEXT"
   #        env:
@@ -33,7 +33,7 @@ jobs:
   # All of this Docker stuff copied from:
   # https://github.com/marketplace/actions/build-and-push-docker-images#complete-workflow
   docker:
-    runs-on: self-hosted
+    runs-on: [self-hosted, docker]
     needs: test
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,8 +69,8 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v1
+#      - name: Setup QEMU
+#        uses: docker/setup-qemu-action@v1
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,8 +69,8 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-#      - name: Setup QEMU
-#        uses: docker/setup-qemu-action@v1
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - name: Run integration tests
@@ -24,7 +24,7 @@ jobs:
 
   #  debug:
   #    needs: test
-  #    runs-on: ubuntu-latest
+  #    runs-on: self-hosted
   #    steps:
   #      - run: echo "$GITHUB_CONTEXT"
   #        env:
@@ -33,7 +33,7 @@ jobs:
   # All of this Docker stuff copied from:
   # https://github.com/marketplace/actions/build-and-push-docker-images#complete-workflow
   docker:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: test
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This uses AWS action runners to run our tests. Seems to be more reliable than the GitHub-provided ones. And we need to self-host Sonarqube anyway which our runners will need access to.

Those AWS runners are configured via the Terraform code in here: https://github.com/fluree/github-actions-runner-aws/pull/1

...and a GitHub app ~~that is under my GitHub account (you can't apparently create this kind of app under an organization for some reason)~~ UPDATE: I was able to transfer it to the Fluree org: https://github.com/apps/aws-action-runners