### PR TITLE
Fix/reset fulltext index workaround

### DIFF
--- a/src/fluree/db/ledger/full_text_index.clj
+++ b/src/fluree/db/ledger/full_text_index.clj
@@ -39,37 +39,40 @@
   ([storage-dir network dbid flakes language]
    (add-flakes-to-store storage-dir network dbid flakes language {}))
   ([storage-dir network dbid flakes language opts]
-   (go-try (let [store           (disk-store storage-dir network dbid)
-                 analyzer        (full-text/analyzer language)
-                 subject-flakes  (group-by #(.-s %) flakes)
-                 subjects        (keys subject-flakes)
-                 timeout-ms      (or (:timeout opts) 500)
-                 max-retry-times (or (:retry opts) 10)]
-             (<? (go-loop [[s & r] subjects]
-                   (if-not s
-                     (do (if subjects (log/info (str "Add full text flakes to store complete for: " (count subjects) " subjects.")))
-                         true)
-                     (let [subject   s
-                           flakes    (get subject-flakes subject)
-                           existing  (-> (try (clucie/search store {:_id (str s)} 1 analyzer 0 1)
-                                              (catch Exception e [])) first)
-                           flake-map (reduce (fn [acc f]
-                                               (assoc acc (keyword (str (.-p f))) (.-o f))) {} flakes)
-                           s-res     (if existing
-                                       (merge existing flake-map)
-                                       (let [cid (flake/sid->cid s)]
-                                         (assoc flake-map :_id s :collection cid)))
-                           add-fn    (if existing
-                                       (fn [] (clucie/update! store s-res (keys s-res) :_id (str s) analyzer))
-                                       (fn [] (clucie/add! store [s-res] (keys s-res) analyzer)))
-                           add-resp  (try (add-fn)
-                                          (catch Exception e (let [cause     (:cause (Throwable->map e))
-                                                                   error-msg "Lock held by this virtual machine"]
-                                                               (if (str/includes? cause error-msg)
-                                                                 (<? (retry-fn add-fn error-msg timeout-ms max-retry-times subject)) (throw e)))))]
-                       (log/trace (str "Added flakes for subject: " subject " to full text index."))
-                       (<? (timeout timeout-ms))
-                       (recur r)))))))))
+   (go-try
+    (let [store           (disk-store storage-dir network dbid)
+          analyzer        (full-text/analyzer language)
+          subject-flakes  (group-by #(.-s %) flakes)
+          subjects        (keys subject-flakes)
+          subject-count   (count subjects)
+          timeout-ms      (or (:timeout opts) 500)
+          max-retry-times (or (:retry opts) 10)]
+      (<? (go-loop [[s & r] subjects]
+            (if-not s
+              (do (when subjects
+                    (log/info (str "Add full text flakes to store complete for: " subject-count " subjects.")))
+                  subject-count)
+              (let [subject   s
+                    flakes    (get subject-flakes subject)
+                    existing  (-> (try (clucie/search store {:_id (str s)} 1 analyzer 0 1)
+                                       (catch Exception e [])) first)
+                    flake-map (reduce (fn [acc f]
+                                        (assoc acc (keyword (str (.-p f))) (.-o f))) {} flakes)
+                    s-res     (if existing
+                                (merge existing flake-map)
+                                (let [cid (flake/sid->cid s)]
+                                  (assoc flake-map :_id s :collection cid)))
+                    add-fn    (if existing
+                                (fn [] (clucie/update! store s-res (keys s-res) :_id (str s) analyzer))
+                                (fn [] (clucie/add! store [s-res] (keys s-res) analyzer)))
+                    add-resp  (try (add-fn)
+                                   (catch Exception e (let [cause     (:cause (Throwable->map e))
+                                                            error-msg "Lock held by this virtual machine"]
+                                                        (if (str/includes? cause error-msg)
+                                                          (<? (retry-fn add-fn error-msg timeout-ms max-retry-times subject)) (throw e)))))]
+                (log/trace (str "Added flakes for subject: " subject " to full text index."))
+                (<? (timeout timeout-ms))
+                (recur r)))))))))
 
 
 (defn remove-flakes-from-store

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -396,9 +396,7 @@
           db             (fdb/db conn ledger)
           storage-dir    (-> conn :meta :file-storage-path)
           reindexed      (<? (full-text/reset-full-text-index db storage-dir network dbid))]
-      [{:status 200} {:block (:block reindexed)
-                      :t     (:t reindexed)
-                      :stats (:stats reindexed)}])))
+      [{:status 200} {:reindex-count reindexed}])))
 
 (defmethod action-handler :export
   [_ system param auth-map ledger _]

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -31,6 +31,7 @@
             [fluree.db.permissions-validate :as permissions-validate]
             [fluree.db.peer.password-auth :as pw-auth]
             [fluree.db.ledger.reindex :as reindex]
+            [fluree.db.ledger.full-text-index :as full-text]
             [fluree.db.ledger.mutable :as mutable]
             [fluree.db.auth :as auth]
             [fluree.db.ledger.delete :as delete])
@@ -386,6 +387,18 @@
                       :t     (:t reindexed)
                       :stats (:stats reindexed)}])))
 
+(defmethod action-handler :reindex-fulltext
+  [_ system _ _ ledger _]
+  ;; For now, does not require authentication
+  (go-try
+    (let [conn           (:conn system)
+          [network dbid] (graphdb/validate-ledger-ident ledger)
+          db             (fdb/db conn ledger)
+          storage-dir    (-> conn :meta :file-storage-path)
+          reindexed      (<? (full-text/reset-full-text-index db storage-dir network dbid))]
+      [{:status 200} {:block (:block reindexed)
+                      :t     (:t reindexed)
+                      :stats (:stats reindexed)}])))
 
 (defmethod action-handler :export
   [_ system param auth-map ledger _]


### PR DESCRIPTION
This is a minimal quick fix for the issues around incomplete full text indexes. 

First, this patch adds more logging around fulltext index actions to make it a little easier to follow along with progress.

Next, this patch adds a "reindex-fulltext" endpoint so end users can kick off a full text reindex manually if their full text index isn't complete

This is a short term quick fix. I think fixing full text indexes so that they are more robust and resilient is a heavier lift. I've started that work on the "bug/incomplete-full-text" branches of the [ledger](https://github.com/fluree/ledger/compare/bug/incomplete-full-text) and [db](https://github.com/fluree/db/compare/bug/incomplete-full-text) repositories.