### PR TITLE
Use new relative block-storage-path fn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:mvn/version "1.0.0-rc4"}
+        com.fluree/db {:mvn/version "1.0.0-rc5"}
         com.fluree/raft {:mvn/version "0.12.0"}
         com.fluree/crypto {:mvn/version "0.3.4"}
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.fluree</groupId>
       <artifactId>db</artifactId>
-      <version>1.0.0-rc4</version>
+      <version>1.0.0-rc5</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/fluree/db/ledger/consensus/dbsync2.clj
+++ b/src/fluree/db/ledger/consensus/dbsync2.clj
@@ -230,7 +230,8 @@
   Puts block file keys (filenames) onto provided port if they are missing."
   [conn network dbid check-through port]
   (go-try
-    (let [file-path    (storage/block-storage-path conn network dbid)
+    (let [file-path    (storage/block-storage-path network dbid)
+          _            (log/debug "check-all-blocks-consistency block-storage-path:" file-path)
           storage-list (:storage-list conn)
           all-files    (<? (storage-list file-path))
           last-element (fn [path] (-> path (str/split #"/") last))

--- a/src/fluree/db/ledger/storage/filestore.clj
+++ b/src/fluree/db/ledger/storage/filestore.clj
@@ -174,7 +174,8 @@
   "Returns a sequence of data maps with keys `#{:name :size :url}` representing
   the files at `base-path/path`."
   [base-path path]
-  (let [full-path (str/join "/" [base-path path])]
+  (let [full-path (str base-path path)]
+    (log/debug "storage-list full-path:" full-path)
     (when (exists? full-path)
       (let [files (-> full-path io/file file-seq)]
         (map (fn [f] {:name (.getName f), :url (.toURL f), :size (.length f)})

--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -409,6 +409,7 @@
         storage-type             (storage-type settings)
         s3-conn                  (some-> settings :fdb-storage-s3-bucket s3store/connect)
         file-ledger-storage-path (file-storage-path :ledger settings)
+        _                        (log/debug "generate-conn-settings file-ledger-storage-path:" file-ledger-storage-path)
         s3-ledger-storage-prefix (:fdb-storage-s3-ledger-prefix settings)
         storage-read             (case storage-type
                                    :file (filestore/connection-storage-read


### PR DESCRIPTION
...to fix dbsync issue. Also adds some storage debug logging that I used this to debug this issue. More debug logging is always better, right?

The core of the fix is the arity change on line 233 of dbsync2.clj.