### PR TITLE
FC-825 Fix/missing db chan take

### DIFF
--- a/src/fluree/db/ledger/full_text_index.clj
+++ b/src/fluree/db/ledger/full_text_index.clj
@@ -49,9 +49,9 @@
           max-retry-times (or (:retry opts) 10)]
       (loop [[s & r] subjects]
         (if-not s
-          (do (when subjects
-                (log/info (str "Add full text flakes to store complete for: " subject-count " subjects.")))
-              subject-count)
+          (do
+            (log/info (str "Add full text flakes to store complete for: " subject-count " subjects."))
+            subject-count)
           (let [subject   s
                 flakes    (get subject-flakes subject)
                 existing  (-> (try (clucie/search store {:_id (str s)} 1 analyzer 0 1)
@@ -112,13 +112,15 @@
 (defn reset-full-text-index
   [db path-to-dir network dbid]
   (go-try
-   (let [start-time (Instant/now)]
+   (let [start-time      (Instant/now)
+         fullTextPreds   (-> db :schema :fullText)
+         full-text-count (count fullTextPreds)]
      (log/info (str "Full-Text Search Index Reset began at: " start-time)
-               {:network network
-                :dbid    dbid})
+               {:network      network
+                :dbid         dbid})
+     (log/info (str "Resetting " full-text-count " full text predicates"))
      (delete-files-recursively (str path-to-dir network "/" dbid "/lucene"))
-     (let [fullTextPreds (-> db :schema :fullText)
-           language      (or (-> db :settings :language) :default)
+     (let [language      (or (-> db :settings :language) :default)
            addFlakes     (loop [[pred & r] fullTextPreds
                                 full []]
                            (if pred

--- a/src/fluree/db/ledger/full_text_index.clj
+++ b/src/fluree/db/ledger/full_text_index.clj
@@ -116,8 +116,8 @@
          fullTextPreds   (-> db :schema :fullText)
          full-text-count (count fullTextPreds)]
      (log/info (str "Full-Text Search Index Reset began at: " start-time)
-               {:network      network
-                :dbid         dbid})
+               {:network network
+                :dbid    dbid})
      (log/info (str "Resetting " full-text-count " full text predicates"))
      (delete-files-recursively (str path-to-dir network "/" dbid "/lucene"))
      (let [language      (or (-> db :settings :language) :default)

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -393,7 +393,7 @@
   (go-try
     (let [conn           (:conn system)
           [network dbid] (graphdb/validate-ledger-ident ledger)
-          db             (fdb/db conn ledger)
+          db             (<? (fdb/db conn ledger))
           storage-dir    (-> conn :meta :file-storage-path)
           reindexed      (<? (full-text/reset-full-text-index db storage-dir network dbid))]
       [{:status 200} {:reindex-count reindexed}])))


### PR DESCRIPTION
Resets were working in a repl, but not from the http api due to a missing take from the db channel.