### PR TITLE
FC-996 exclude private key from raft networks section, make async

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -652,7 +652,6 @@
                                                    :active? (> (:expire item) instant)}]))
                               acc)))
               raft'     (-> raft
-                            (dissoc :cmd-queue :new-db-queue :networks)
                             (assoc :cmd-queue cmd-q
                                    :new-db-queue new-db-q
                                    :networks nw-data))


### PR DESCRIPTION
Update nw-state to be 1) async and 2) use clojure-walk to remove :private-key from raft :networks section.  
