### PR TITLE
 FC-516 Bug/empty indexer

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:mvn/version "1.0.0-rc7"}
+        com.fluree/db {:mvn/version "1.0.0-rc8"}
         com.fluree/raft {:mvn/version "0.12.0"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -394,7 +394,7 @@
    (let [conn           (:conn system)
          indexer        (-> conn :full-text/indexer :process)
          [network dbid] (graphdb/validate-ledger-ident ledger)
-         db             (fdb/db conn ledger)
+         db             (<? (fdb/db conn ledger))
          reindex-status (<? (indexer {:action :reset, :db db}))]
      [{:status 200} reindex-status])))
 

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -134,15 +134,13 @@
                                                   :memory memorystore/connection-storage-write)
                               producer-chan     (async/chan (async/sliding-buffer 100))
                               publish-fn        (local-message-process {:config config :group group} producer-chan)
-                              full-text-indexer (when (= storage-type :file) (full-text/start-indexer))
+                              full-text-indexer (full-text/start-indexer)
                               conn-impl         (if transactor?
                                                   (connection/connect nil (assoc conn-opts :storage-write storage-write-fn :publish publish-fn :memory? memory?))
                                                   (connection/connect (:fdb-group-servers-ports settings) (assoc conn-opts :memory? memory?)))]
                           ;; launch message consumer, handles messages back from ledger
                           (local-message-response conn-impl producer-chan)
-                          (-> conn-impl
-                              (assoc :group group)
-                              (assoc-some :full-text/indexer full-text-indexer)))
+                          (assoc conn-impl :group group, :full-text/indexer full-text-indexer))
          system         {:config    config
                          :conn      conn
                          :webserver nil

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -134,10 +134,10 @@
                                                   :memory memorystore/connection-storage-write)
                               producer-chan     (async/chan (async/sliding-buffer 100))
                               publish-fn        (local-message-process {:config config :group group} producer-chan)
-                              full-text-indexer (full-text/start-indexer)
                               conn-impl         (if transactor?
                                                   (connection/connect nil (assoc conn-opts :storage-write storage-write-fn :publish publish-fn :memory? memory?))
-                                                  (connection/connect (:fdb-group-servers-ports settings) (assoc conn-opts :memory? memory?)))]
+                                                  (connection/connect (:fdb-group-servers-ports settings) (assoc conn-opts :memory? memory?)))
+                              full-text-indexer (full-text/start-indexer conn-impl)]
                           ;; launch message consumer, handles messages back from ledger
                           (local-message-response conn-impl producer-chan)
                           (-> conn-impl

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -101,7 +101,7 @@
 (defn assoc-some
   "Assoc k -> v in m if v is not nil. Returns m unaltered otherwise."
   [m k v]
-  (if (nil? v)
+  (if-not (nil? v)
     (assoc m k v)
     m))
 

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -140,7 +140,9 @@
                                                   (connection/connect (:fdb-group-servers-ports settings) (assoc conn-opts :memory? memory?)))]
                           ;; launch message consumer, handles messages back from ledger
                           (local-message-response conn-impl producer-chan)
-                          (assoc conn-impl :group group, :full-text/indexer full-text-indexer))
+                          (-> conn-impl
+                              (assoc :group group)
+                              (assoc-some :full-text/indexer full-text-indexer)))
          system         {:config    config
                          :conn      conn
                          :webserver nil


### PR DESCRIPTION
The full text indexer was failing to start because we can't rely on the storage-type to be set on the connections. This patch uses the api change in https://github.com/fluree/db/pull/27 and starts the indexer if and only if the file-storage-path is set. This relies on https://github.com/fluree/db/pull/27 and can't be merged until a new library version is published.