### PR TITLE
FC-1005 add newer Admin UI pages to resource list; return networks in vector

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -642,7 +642,7 @@
                                   acc* (into acc [{(keyword k) (count v)}])]
                               (recur r acc*))
                             acc))
-              nw-data   (remove-deep [:private-key] networks)
+              nw-data   (-> (remove-deep [:private-key] networks) vector)
               svr-state (when-let [servers (into [] (:servers leases))]
                           (loop [[server & r] servers
                                  acc []]
@@ -951,6 +951,9 @@
                                  (compojure/GET "/schema" [] (resp/resource-response "index.html" {:root "adminUI"}))
                                  (compojure/GET "/import" [] (resp/resource-response "index.html" {:root "adminUI"}))
                                  (compojure/GET "/permissions" [] (resp/resource-response "index.html" {:root "adminUI"}))
+                                 (compojure/GET "/exploredb" [] (resp/resource-response "index.html" {:root "adminUI"}))
+                                 (compojure/GET "/networkdashboard" [] (resp/resource-response "index.html" {:root "adminUI"}))
+                                 (compojure/GET "/transact" [] (resp/resource-response "index.html" {:root "adminUI"}))
                                  (constantly not-found))))
 
                            :access-control-allow-origin [#".+"]

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -642,7 +642,7 @@
                                   acc* (into acc [{(keyword k) (count v)}])]
                               (recur r acc*))
                             acc))
-              nw-data   (-> (remove-deep [:private-key] networks) vector)
+              nw-data   (->> networks (remove-deep [:private-key]) vector)
               svr-state (when-let [servers (into [] (:servers leases))]
                           (loop [[server & r] servers
                                  acc []]


### PR DESCRIPTION
A couple of changes for the latest Admin UI:
1) Added all newer pages to the http-api resource list, even the ones that previously worked
2) changed nw-state end point to return networks data in a vector.  