### PR TITLE
Feature: Support homebrew 1.0 formula

### DIFF
--- a/resources/fluree_sample.properties
+++ b/resources/fluree_sample.properties
@@ -9,7 +9,7 @@
 ### Base Settings
 
 # Main 'mode' to start this instance of Fluree in.
-# Can be dev, query or ledger. Typically over-ride by environment variable passed at startup
+# Can be dev, query or ledger (defaults to query).
 fdb-mode=dev
 
 ############################################################
@@ -22,7 +22,7 @@ fdb-mode=dev
 fdb-consensus-type=raft
 
 # If this server is joining an existing network, list true (defaults to false)
-fdb-join?=false
+#fdb-join?=false
 
 # When adding a new server, the number of rounds to wait for the server to sync its logs.
 # If it is not synced in this amount of time, this server will not be added to the network
@@ -32,10 +32,16 @@ fdb-group-catch-up-rounds=10
 # We will auto-generation one if not provided, and store it at fdb-group-private-key-file.
 # Take care not to lose it, or generate a new one and use it instead by executing
 # FlureeDB with the command :keygen
-fdb-group-private-key=
+#fdb-group-private-key=
 
-# If fdb-group-private-key is not provided, we'll look for it in this file
-# If not found in this file, we'll generate a default one and place it in this file
+# Path to config directory where fluree.properties, default-private-key.txt, etc. will be
+# read / written. Defaults to ./
+#fdb-group-config-path=./
+
+# If fdb-group-private-key is not provided, we'll look for it in this file (in
+# fdb-group-config-path).
+# If not found in this file, we'll generate a default one and place it in this
+# file (in fdb-group-config-path).
 fdb-group-private-key-file=default-private-key.txt
 
 # List all servers participating in ledger-group with format of server-id@host:port
@@ -58,7 +64,7 @@ fdb-group-timeout=2000
 # Tx group leader will send out a heartbeat at this interval. By default, will be 1/2 of fdb-group-timeout
 # This can never be less than fdb-group-timeout, and ideally should be 1/3 to 1/2 of that value.
 # A number in milliseconds can be provided, or can be used with units such as 1000ms or 1s
-fdb-group-heartbeat=
+#fdb-group-heartbeat=
 
 # Where to store tx-group raft log files. These logs have fairly frequent disk access.
 # This is always a local filesystem path and must start with either `/` or `./`.
@@ -110,13 +116,13 @@ fdb-stats-report-frequency=1m
 # If an encryption secret (any string) is provided, Fluree will use AES Encryption when storing files to disk.
 # Note all servers that will be reading files must have the same encryption secret, and if the secret is lost
 # all data will be unrecoverable.
-fdb-encryption-secret=
+#fdb-encryption-secret=
 
 ############################################################
 ### HTTP API port
 
-# Port in which the query peers will respond to API calls from clients
-fdb-api-port=8080
+# Port in which the query peers will respond to API calls from clients (defaults to 8090).
+#fdb-api-port=8080
 
 # If fdb-api-open is true, will allow full access on above port for any request and will
 # utilize default auth identity to regulate query/read permissions. If false, every request
@@ -172,7 +178,7 @@ fdb-pw-auth-jwt-secret=
 # A valid Fluree private key with proper permissions must be used to sign
 # any new transaction where new password auth records are created. If a
 # default root key still exists and has proper permission, that will be used by default.
-fdb-pw-auth-signing-key=
+#fdb-pw-auth-signing-key=
 
 
 ############################################################
@@ -181,16 +187,16 @@ fdb-pw-auth-signing-key=
 # External port to expose for external ledger communication. If using a ledger group behind a
 # load balancer then this should be consistent across the ledger group.
 # i.e. fdb-ledger-port=9795
-fdb-ledger-port=
+#fdb-ledger-port=
 
 # List each auth identity private key at each network and/or database you are participating in.
 # Format is private-key1@network/db,private-key2@network/db2 where the db is optional and multiple
 # dbs or networks are separated by commas. If only a network is specified, the private key will be  used
 # as a default for all databases on that network and it is assumed this server is participating with every database.
 # i.e. fdb-ledger-private-keys=53ab638dd26d02d95214f58eb5df0b086baba584c66f6ae5b8574d722c6bc3f3@networka/dbname
-fdb-ledger-private-keys=
+#fdb-ledger-private-keys=
 
 # List of seed servers to contact for each network/db. Like fdb-ledger-identities, the db is optional.
 # Every network/db + server address combination should be separated by a comma
 # i.e. fdb-ledger-servers=networka@some-domain.com:9795,networka@10.1.1.2:9795,networkb/dbname@external.dot.com:9795
-fdb-ledger-servers=
+#fdb-ledger-servers=

--- a/resources/fluree_start.sh
+++ b/resources/fluree_start.sh
@@ -170,6 +170,14 @@ if [ "$1" == "test" ]; then
   exit 0
 fi
 
+# This needs to stay down here so that all of the checks above run first.
+# Basically the purpose of this is get right up to the point of starting Fluree
+# and then exit successfully iff we got that far.
+if [ "$1" == "test" ]; then
+    echo "Fluree successfully installed and ready to run"
+    exit 0
+fi
+
 echo "Fluree ledger starting with properties file: ${FLUREE_PROPERTIES}"
 echo "Fluree ledger starting with java options: ${XMS} ${XMX} ${JAVA_OPTS}"
 

--- a/resources/fluree_start.sh
+++ b/resources/fluree_start.sh
@@ -170,14 +170,6 @@ if [ "$1" == "test" ]; then
   exit 0
 fi
 
-# This needs to stay down here so that all of the checks above run first.
-# Basically the purpose of this is get right up to the point of starting Fluree
-# and then exit successfully iff we got that far.
-if [ "$1" == "test" ]; then
-    echo "Fluree successfully installed and ready to run"
-    exit 0
-fi
-
 echo "Fluree ledger starting with properties file: ${FLUREE_PROPERTIES}"
 echo "Fluree ledger starting with java options: ${XMS} ${XMX} ${JAVA_OPTS}"
 

--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -27,6 +27,7 @@
    :fdb-consensus-type           "raft"                     ;; raft
    :fdb-encryption-secret        nil                        ;; Text encryption secret for encrypting data at rest and in transit
 
+   :fdb-group-config-path        "./"
    :fdb-group-private-key        nil
    :fdb-group-private-key-file   nil                        ;; optional location of file that contains group private key
 
@@ -287,13 +288,13 @@
   (or (when-let [priv (:fdb-group-private-key env)] (str/trim priv))
       (let [priv-key-file (or (:fdb-group-private-key-file env)
                               "default-private-key.txt")
-            file          (io/file priv-key-file)
+            file          (io/file (:fdb-group-config-path env) priv-key-file)
             exists?       (.exists file)]
         (if exists?
-          (str/trim (slurp priv-key-file))
+          (str/trim (slurp file))
           ;; make sure private key generated is 64 characters
           (let [key-pair (some #(when (= 64 (count (:private %))) %) (repeatedly crypto/generate-key-pair))]
-            (spit priv-key-file (:private key-pair))
+            (spit file (:private key-pair))
             (:private key-pair))))))
 
 


### PR DESCRIPTION
This contains the changes needed for [the updated homebrew formula](https://github.com/fluree/homebrew-flureedb/pull/1) to work.

The primary change in here is the addition of the new `fdb-group-config-path` config param. This allows us to read and write files like `default-private-key.txt` when running from the Homebrew launchd plist. In this mode, there is no current directory that we can assume holds a git clone or unzipped fluree release, and we can't write to it. This config param allows me to set this to Homebrew's `etc` directory. See the linked homebrew formula PR above for details.