### PR TITLE
FC-1042 "forget" full-text indexes when deleting a ledger

### DIFF
--- a/src/fluree/db/ledger/indexing/full_text.clj
+++ b/src/fluree/db/ledger/indexing/full_text.clj
@@ -283,6 +283,7 @@
               (let [result  (case (:action msg)
                               :block (let [{:keys [block]} msg]
                                        (<! (write-block writer db block)))
+                              :forget (full-text/forget writer)
                               :range (let [{:keys [start end]} msg]
                                        (<! (write-range writer db start end)))
                               :reset (<! (full-reset writer db))


### PR DESCRIPTION
This commit cleans up full-text indexes when deleting a ledger.  