### PR TITLE
Generate default private key if missing

### DIFF
--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -540,8 +540,8 @@
                                          (:fdb-group-private-key settings)
                                          (into (str/split (:fdb-group-private-key settings) #","))
 
-                                         (:fdb-group-private-key-file settings)
-                                         (into (->> (slurp (:fdb-group-private-key-file settings))
+                                         :else
+                                         (into (->> (get-or-generate-tx-private-key settings)
                                                     (str/split-lines)
                                                     (filter not-empty)
                                                     (reduce #(if (str/includes? %2 ",")


### PR DESCRIPTION
I ran into an error here when it tried to start up w/ no `default-private-key.txt` in the group config path.