### PR TITLE
Feature: ledger version available via API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RELEASE_BUCKET ?= fluree-releases-public
 MINIMUM_JAVA_VERSION ?= 11
 JAVA_VERSION_FOR_RELEASE_BUILDS := $(MINIMUM_VERSION)
 
-VERSION := $(shell mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null)
+VERSION := $(shell clojure -M:meta version)
 VERSION ?= SNAPSHOT
 
 MAJOR_VERSION := $(shell echo $(VERSION) | cut -d '.' -f1)
@@ -14,6 +14,9 @@ SOURCES := $(shell find src)
 RESOURCES := $(shell find resources)
 
 DESTDIR ?= /usr/local
+
+print-version:
+	@echo $(VERSION)
 
 build/fluree-$(VERSION).zip: stage-release
 	cd build && zip -r fluree-$(VERSION).zip * -x 'data/' 'data/**' 'release-staging/' 'release-staging/**'

--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ You can run the integration tests like this:
 
 ### Building
 
-1. Install maven
-    1. macOS: `brew install maven`
-    1. Arch Linux: `pacman -S maven`
 1. Set the version you want in `pom.xml`
 1. Run `make`
 

--- a/deps.edn
+++ b/deps.edn
@@ -49,4 +49,7 @@
    :exec-fn hf.depstar/uberjar
    :exec-args {:jar "target/fluree-ledger.standalone.jar"
                :aot true
-               :main-class fluree.db.server}}}}
+               :main-class fluree.db.server}}
+
+  :meta
+  {:main-opts ["-m" "fluree.db.meta"]}}}

--- a/src/fluree/db/meta.clj
+++ b/src/fluree/db/meta.clj
@@ -1,0 +1,36 @@
+(ns fluree.db.meta
+  (:require [clojure.data.xml :as xml]
+            [clojure.java.io :as io])
+  (:gen-class))
+
+
+(defn el-content
+  "Get the contents of XML element named el-name (keyword) from
+  clojure.data.xml-parsed xml"
+  [xml el-name]
+  (when-let [el (->> xml (filter #(= (:tag %) el-name)) first)]
+    (:content el)))
+
+
+(defn find-pom-xml []
+  (let [root-file (io/file "pom.xml")]
+    (if (.exists root-file)
+      root-file
+      ;; If it's not at the project root, assume we're running from a JAR and
+      ;; look for it in there.
+      (io/resource "META-INF/maven/com.fluree/ledger/pom.xml"))))
+
+
+(defn version []
+  (let [pom-xml (find-pom-xml)
+        pom     (-> pom-xml slurp (xml/parse-str :namespace-aware false))
+        _       (assert (= :project (:tag pom))
+                        (str "pom.xml appears malformed; expected top-level project element; got "
+                             (:tag pom) " instead"))
+        project (:content pom)]
+    (-> project (el-content :version) first)))
+
+
+(defn -main [cmd & _]
+  (case cmd
+    "version" (println (version))))

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -926,6 +926,12 @@
                                      uri))))))
 
 
+(defn wrap-version-header [handler]
+  (fn [request]
+    (let [response (handler request)]
+      (assoc-in response [:headers "X-Fdb-Version"] (meta/version)))))
+
+
 (defn- api-routes
   [system]
   (compojure/routes
@@ -968,6 +974,7 @@
         ;; final 404 fallback
         (constantly not-found))
 
+      wrap-version-header
       params/wrap-params
       (->> (wrap-errors (:debug-mode? system)))
       (cors/wrap-cors

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -615,9 +615,9 @@
 (defn- remove-deep
   [key-set data]
   (walk/prewalk (fn [node] (if (map? node)
-                                     (apply dissoc node key-set)
-                                     node))
-                        data))
+                             (apply dissoc node key-set)
+                             node))
+                data))
 
 (defn nw-state
   [system request]
@@ -854,7 +854,7 @@
                                                        :auth)
                                           db'      (<? (fdb/db (:conn system) db-name))
                                           auth-id' (<? (dbproto/-subid db' ["_auth/id" jwt-auth] true))
-                 _                                 (when (util/exception? auth-id')
+                                          _        (when (util/exception? auth-id')
                                                      (throw (ex-info (str "Auth id for request does not exist in the database: " jwt-auth)
                                                                      {:status 403 :error :db/invalid-auth})))]
                                       jwt-auth))
@@ -921,44 +921,45 @@
 ;; TODO - handle CORS more reasonably for production
 (defn- make-handler
   [system]
-  (ignore-trailing-slash (cors/wrap-cors
-                           (wrap-errors
-                             (:debug-mode? system)
-                             (params/wrap-params
-                               (compojure/routes
-                                 (compojure/GET "/fdb/storage/:network/:db/:type" request (storage-handler system request))
-                                 (compojure/GET "/fdb/storage/:network/:db/:type/:key" request (storage-handler system request))
-                                 (compojure/GET "/fdb/ws" request (websocket/handler system request))
-                                 (compojure/ANY "/fdb/health" request (health-handler system request))
-                                 (compojure/ANY "/fdb/nw-state" request (nw-state system request))
-                                 (compojure/POST "/fdb/add-server" request (add-server system request))
-                                 (compojure/POST "/fdb/remove-server" request (remove-server system request))
-                                 (compojure/POST "/fdb/sub" request (subscription-handler system request))
-                                 (compojure/GET "/fdb/new-keys" request (keys-handler system request))
-                                 (compojure/POST "/fdb/new-keys" request (keys-handler system request))
-                                 (compojure/POST "/fdb/dbs" request (get-ledgers system request))
-                                 (compojure/GET "/fdb/dbs" request (get-ledgers system request))
-                                 (compojure/POST "/fdb/new-db" request (new-ledger system request))
-                                 (compojure/POST "/fdb/delete-db" request (delete-ledger system request))
-                                 (compojure/POST "/fdb/:network/:db/pw/:action" request (password-handler system request))
-                                 (compojure/POST "/fdb/:network/:db/:action" request (wrap-action-handler system request))
-                                 (compojure/GET "/" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (route/resources "/" {:root "adminUI"})
-                                 (compojure/GET "/account" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/flureeql" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/graphql" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/sparql" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/schema" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/import" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/permissions" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/exploredb" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/networkdashboard" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (compojure/GET "/transact" [] (resp/resource-response "index.html" {:root "adminUI"}))
-                                 (constantly not-found))))
+  (ignore-trailing-slash
+    (cors/wrap-cors
+      (wrap-errors
+        (:debug-mode? system)
+        (params/wrap-params
+          (compojure/routes
+            (compojure/GET "/fdb/storage/:network/:db/:type" request (storage-handler system request))
+            (compojure/GET "/fdb/storage/:network/:db/:type/:key" request (storage-handler system request))
+            (compojure/GET "/fdb/ws" request (websocket/handler system request))
+            (compojure/ANY "/fdb/health" request (health-handler system request))
+            (compojure/ANY "/fdb/nw-state" request (nw-state system request))
+            (compojure/POST "/fdb/add-server" request (add-server system request))
+            (compojure/POST "/fdb/remove-server" request (remove-server system request))
+            (compojure/POST "/fdb/sub" request (subscription-handler system request))
+            (compojure/GET "/fdb/new-keys" request (keys-handler system request))
+            (compojure/POST "/fdb/new-keys" request (keys-handler system request))
+            (compojure/POST "/fdb/dbs" request (get-ledgers system request))
+            (compojure/GET "/fdb/dbs" request (get-ledgers system request))
+            (compojure/POST "/fdb/new-db" request (new-ledger system request))
+            (compojure/POST "/fdb/delete-db" request (delete-ledger system request))
+            (compojure/POST "/fdb/:network/:db/pw/:action" request (password-handler system request))
+            (compojure/POST "/fdb/:network/:db/:action" request (wrap-action-handler system request))
+            (compojure/GET "/" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (route/resources "/" {:root "adminUI"})
+            (compojure/GET "/account" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/flureeql" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/graphql" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/sparql" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/schema" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/import" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/permissions" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/exploredb" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/networkdashboard" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/transact" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (constantly not-found))))
 
-                           :access-control-allow-origin [#".+"]
-                           :access-control-expose-headers ["X-Fdb-Block" "X-Fdb-Fuel" "X-Fdb-Status" "X-Fdb-Time"]
-                           :access-control-allow-methods [:get :put :post :delete])))
+      :access-control-allow-origin [#".+"]
+      :access-control-expose-headers ["X-Fdb-Block" "X-Fdb-Fuel" "X-Fdb-Status" "X-Fdb-Time"]
+      :access-control-allow-methods [:get :put :post :delete])))
 
 (defrecord WebServer [close])
 

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -627,8 +627,8 @@
                              node))
                 data))
 
-(defn nw-state
-  [system request]
+(defn nw-state-handler
+  [system _]
   (let [deferred (d/deferred)]
     (async/go
       (try
@@ -933,7 +933,7 @@
     (compojure/GET "/fdb/storage/:network/:db/:type/:key" request (storage-handler system request))
     (compojure/GET "/fdb/ws" request (websocket/handler system request))
     (compojure/ANY "/fdb/health" request (health-handler system request))
-    (compojure/ANY "/fdb/nw-state" request (nw-state system request))
+    (compojure/ANY "/fdb/nw-state" request (nw-state-handler system request))
     (compojure/GET "/fdb/version" request (version-handler system request))
     (compojure/POST "/fdb/add-server" request (add-server system request))
     (compojure/POST "/fdb/remove-server" request (remove-server system request))

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -927,6 +927,7 @@
         (:debug-mode? system)
         (params/wrap-params
           (compojure/routes
+            ;; API routes
             (compojure/GET "/fdb/storage/:network/:db/:type" request (storage-handler system request))
             (compojure/GET "/fdb/storage/:network/:db/:type/:key" request (storage-handler system request))
             (compojure/GET "/fdb/ws" request (websocket/handler system request))
@@ -943,18 +944,17 @@
             (compojure/POST "/fdb/delete-db" request (delete-ledger system request))
             (compojure/POST "/fdb/:network/:db/pw/:action" request (password-handler system request))
             (compojure/POST "/fdb/:network/:db/:action" request (wrap-action-handler system request))
+            ;; Add any new /fdb/ API routes to the section above
+
+            ;; If we reach here with a path that starts with /fdb/, return a 404
+            (compojure/ANY "/fdb/*" [] not-found)
+
+            ;; admin UI routes
             (compojure/GET "/" [] (resp/resource-response "index.html" {:root "adminUI"}))
             (route/resources "/" {:root "adminUI"})
-            (compojure/GET "/account" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/flureeql" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/graphql" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/sparql" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/schema" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/import" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/permissions" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/exploredb" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/networkdashboard" [] (resp/resource-response "index.html" {:root "adminUI"}))
-            (compojure/GET "/transact" [] (resp/resource-response "index.html" {:root "adminUI"}))
+            (compojure/GET "/:page" [] (resp/resource-response "index.html" {:root "adminUI"}))
+
+            ;; Final 404 fallback
             (constantly not-found))))
 
       :access-control-allow-origin [#".+"]

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -34,7 +34,8 @@
             [fluree.db.ledger.reindex :as reindex]
             [fluree.db.ledger.mutable :as mutable]
             [fluree.db.auth :as auth]
-            [fluree.db.ledger.delete :as delete])
+            [fluree.db.ledger.delete :as delete]
+            [fluree.db.meta :as meta])
   (:import (java.io Closeable)
            (java.time Instant)
            (java.net BindException)
@@ -612,6 +613,13 @@
       :login (password-login system ledger request)
       :generate (password-generate system ledger request))))
 
+
+(defn version-handler [system request]
+  {:headers {"Content-Type" "text/plain"}
+   :status  200
+   :body    (meta/version)})
+
+
 (defn- remove-deep
   [key-set data]
   (walk/prewalk (fn [node] (if (map? node)
@@ -933,6 +941,7 @@
             (compojure/GET "/fdb/ws" request (websocket/handler system request))
             (compojure/ANY "/fdb/health" request (health-handler system request))
             (compojure/ANY "/fdb/nw-state" request (nw-state system request))
+            (compojure/GET "/fdb/version" request (version-handler system request))
             (compojure/POST "/fdb/add-server" request (add-server system request))
             (compojure/POST "/fdb/remove-server" request (remove-server system request))
             (compojure/POST "/fdb/sub" request (subscription-handler system request))


### PR DESCRIPTION
This implements FC-930 by adding a new response header `X-Fdb-Version` to every API response as well as exposing a new `/fdb/version` API resource that returns the current ledger version as plain text (should we use JSON instead? e.g. `{"version": "1.0.0-beta6"}`).

It also refactors the API and adminUI routes a bit. Let me know if you'd prefer those be split out of this PR, as I don't think they're essential to this work. I saw it more as a target-of-opportunity to clean things up in there. But if the changes are at all controversial, I can revert them for separate discussion at a later date.

This change also obviates the need to install maven, which is nice.

I'm going to build on (the approved / merged version of) this to show the current ledger version in the adminUI footer.