### PR TITLE
FC-1098 index underflow condition bug fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,7 @@
  :aliases
  {:mvn/group-id com.fluree
   :mvn/artifact-id ledger
-  :mvn/version "1.0.0-beta8"
+  :mvn/version "1.0.0-beta9"
 
   :dev
   {:extra-paths ["dev"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
         com.fluree/db {:git/url "https://github.com/fluree/db"
-                       :sha "9f68f7f298decaae4ccd09b0c7a3e43e30f3ea70"}
+                       :sha "68c2f103944c871c38f032c068c73260ed4054c7"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:git/url "https://github.com/fluree/db"
-                       :sha "68c2f103944c871c38f032c068c73260ed4054c7"}
+        com.fluree/db {:mvn/version "1.0.0-rc16"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:mvn/version "1.0.0-rc15"}
+        com.fluree/db {:git/url "https://github.com/fluree/db"
+                       :sha "9f68f7f298decaae4ccd09b0c7a3e43e30f3ea70"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/src/fluree/db/ledger/consensus/update_state.clj
+++ b/src/fluree/db/ledger/consensus/update_state.clj
@@ -208,7 +208,7 @@
         (event-bus/publish :new-index [network dbid] index)
         true)
       (do
-        (log/warn (str "Attempt to update index failed. Index must be more current and submission server must be currently assigned"
+        (log/warn (str "Skipping index update (maybe reindexing?). Index must be more current and submission server must be currently assigned"
                        " Current index: " current-index
                        " Proposed index: " index
                        " Submission server: " submission-server

--- a/src/fluree/db/ledger/reindex.clj
+++ b/src/fluree/db/ledger/reindex.clj
@@ -183,7 +183,7 @@
                      indexed-db)                            ;; final index if any novelty
                    db))
              (let [{:keys [flakes]} block-data
-                   db*          (<? (dbproto/-with db block flakes))
+                   db*          (<? (dbproto/-with db block flakes {:reindex? true}))
                    novelty-size (get-in db* [:novelty :size])]
                (log/info (str "  -> Reindex dbid: " dbid " block: " block " containing " (count flakes) " flakes. Novelty size: " novelty-size "."))
                (if (>= novelty-size max-novelty)


### PR DESCRIPTION
Issue existed where in an index underflow condition, when combining with the previous/right hand side nodes, the index pointers could become out of sync.

This only happened if the following combo all happened together: (a) index underflow, (b) combine underflow node with right hand side, and (c) right hand side was also updated during same indexing operation.