### PR TITLE
FC-1119: Run transaction tests too

### DIFF
--- a/test/fluree/db/ledger/docs/transact/transactions.clj
+++ b/test/fluree/db/ledger/docs/transact/transactions.clj
@@ -1,12 +1,9 @@
 (ns fluree.db.ledger.docs.transact.transactions
   (:require [clojure.test :refer :all]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
-            [fluree.db.ledger.main-test :as test]
+            [fluree.db.ledger.test-helpers :as test]
             [fluree.db.api :as fdb]
-            [clojure.core.async :as async]
-            [clojure.java.io :as io]
-            [clojure.tools.reader.edn :as edn]
-            [fluree.db.util.log :as log]))
+            [clojure.core.async :as async]))
 
 (use-fixtures :once test/test-system)
 
@@ -20,18 +17,6 @@
   []
   (:conn test/system))
 
-(defn issue-consecutive-transactions
-  ([ledger txns]
-   (issue-consecutive-transactions ledger txns {}))
-  ([ledger txns opts]
-   (let [conn (get-conn)]
-     (async/go-loop [results []
-                     [txn & r] txns]
-       (let [resp    (async/<!! (fdb/transact-async conn ledger txn opts))
-             results (conj results resp)]
-         (if r
-           (recur results r)
-           results))))))
 
 ;; Add collections
 

--- a/test/fluree/db/ledger/ledger_test.clj
+++ b/test/fluree/db/ledger/ledger_test.clj
@@ -21,6 +21,8 @@
             [fluree.db.ledger.docs.smart-functions.rule-example :as rule-example]
             [fluree.db.ledger.docs.smart-functions.in-transactions :as in-transactions]
 
+            [fluree.db.ledger.docs.transact.transactions :as transactions]
+
             [fluree.db.ledger.docs.identity.auth :as auth]
             [fluree.db.ledger.docs.identity.signatures :as signatures]
 
@@ -75,7 +77,9 @@
              (graphql/graphql-test)
              (sql/query-tests)
 
-             ;; 4- Transact
+             ;; 4- Transactions
+             (test/print-banner "Transaction Tests")
+             (transactions/transaction-basics)
 
              ;; 5- Identity
              (test/print-banner "Identity Tests")


### PR DESCRIPTION
Not sure why these weren't included. Ideally we wouldn't be pulling the various tests in manually like this, but instead letting the test runner find them all and run them. But at least these will get run now too.