### PR TITLE
FC-1059 Fix/multiple _id in selects

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:mvn/version "1.0.0-rc17"}
+        com.fluree/db {:git/url "https://github.com/fluree/db"
+                       :sha "c215edf14dc70f65eac30692c830770e3ce9e5f2"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:git/url "https://github.com/fluree/db"
-                       :sha "c215edf14dc70f65eac30692c830770e3ce9e5f2"}
+        com.fluree/db {:mvn/version "1.0.0-rc18"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -771,7 +771,7 @@
                                              (if subject
                                                {:db      db-after
                                                 :instant block-instant
-                                                :sid     (get subject "_id")
+                                                :sid     (:_id subject)
                                                 :flakes  flakes
                                                 :auth_id auth_id
                                                 :state   (atom {:stack   []

--- a/src/fluree/db/ledger/upgrade.clj
+++ b/src/fluree/db/ledger/upgrade.clj
@@ -71,17 +71,6 @@
       (str/replace #"[^a-z0-9-]" "")))
 
 
-(defn ledger-rename-collision-check
-  [conn]
-  (let [ledger-list  @(fdb/ledger-list conn)
-        ledger-names (-> (map (fn [[nw db]]
-                                [nw db (rename-nw-or-db nw) (rename-nw-or-db db)]) ledger-list) set)]
-    (if (not= (count ledger-list) (count ledger-names))
-      (throw (ex-info (str "Cannot rename databases, there would be at least one collision. Ledger names: " ledger-list)
-                      {:status 400
-                       :error  :db/invalid-db}))
-      ledger-names)))
-
 (defn update-dbid-state-atom-networks
   [state-atom old-network old-db new-network new-db]
   (let [old-value (get-in @state-atom [:networks old-network :dbs old-db])

--- a/test/fluree/db/ledger/docs/query/advanced_query.clj
+++ b/test/fluree/db/ledger/docs/query/advanced_query.clj
@@ -131,7 +131,7 @@
     (is (= 3 (count (:chatQuery res))))
 
     (is (= #{351843720888320 351843720888321 351843720888323}
-           (-> (map #(get-in % ["chat/person" "_id"]) (:chatQuery res)) set)))
+           (-> (map #(get-in % ["chat/person" :_id]) (:chatQuery res)) set)))
 
     (is (= 6 (count (:personQuery res))))
 

--- a/test/fluree/db/ledger/docs/query/analytical_query.clj
+++ b/test/fluree/db/ledger/docs/query/analytical_query.clj
@@ -89,7 +89,7 @@
         db  (basic/get-db test/ledger-chat)
         res (async/<!! (fdb/query-async db crawl-query))]
     (is (vector? res))
-    (is (contains? (first res) "_id"))
+    (is (contains? (first res) :_id))
     (is (contains? (first res) "artist/name"))
     (is (contains? (first res) "person/_favArtists"))
     (is (vector? (get (first res) "person/_favArtists")))))

--- a/test/fluree/db/ledger/docs/query/basic_query.clj
+++ b/test/fluree/db/ledger/docs/query/basic_query.clj
@@ -55,7 +55,7 @@
                             ["?person", "person/handle", "jdoe"]]} ; get ids of interest
         db         (basic/get-db test/ledger-chat)
         base-res   (async/<!! (fdb/query-async db chat-base))
-        person-id  (-> base-res (get "chat/person") (get "_id"))
+        person-id  (-> base-res (get "chat/person") :_id)
         chat       (async/<!!
                      (fdb/query-async
                        db {:selectOne ["person/handle"] :from person-id}))]
@@ -82,7 +82,7 @@
     (is (= (count (get res "person/favMovies")) 3))
 
     ; check ids
-    (let [id   (get res "_id")
+    (let [id   (:_id res)
           res' (async/<!! (fdb/query-async db {:selectOne ["*"]
                                                :from id}))]
       (is (= (get res "person/handle") (get res' "person/handle")))
@@ -96,7 +96,7 @@
         db  (basic/get-db test/ledger-chat)
         res (async/<!! (fdb/query-async db chat-query))]
 
-    (is (subset? #{369435906932737 387028092977153} (-> (map #(get % "_id") res) set)))
+    (is (subset? #{369435906932737 387028092977153} (-> (map #(:_id %) res) set)))
 
     (is (= (-> (map #(get % "person/handle") res) set) #{nil "jdoe" "zsmith"}))))
 

--- a/test/fluree/db/ledger/docs/query/graphql.clj
+++ b/test/fluree/db/ledger/docs/query/graphql.clj
@@ -12,7 +12,7 @@
   (let [graphql-query      {:query "{ graph {\n  chat {\n    _id\n    message\n  }\n}\n}"}
         res (async/<!! (fdb/graphql-async (basic/get-conn) test/ledger-chat graphql-query))]
     (is (coll? (:chat res)))
-    (is (every? #(get % "_id") (:chat res)))))
+    (is (every? #(:_id %) (:chat res)))))
 
 (deftest graphql-crawl-query
   (testing "GraphQL query that crawls from chat to referenced person")
@@ -26,7 +26,7 @@
   (let [graphql-query      {:query "{ graph {\n  person {\n    *\n  }\n}\n}"}
         res (async/<!! (fdb/graphql-async (basic/get-conn) test/ledger-chat graphql-query))]
 
-    (is (every? #(get % "_id") (:person res)))))
+    (is (every? #(:_id %) (:person res)))))
 
 (deftest graphql-reverse-crawl-query
   (testing "GraphQL query that reverse-crawls from person back to chat")


### PR DESCRIPTION
Select :* queries returned both an :_id and "_id" depending on the parsing logic. This fixes it. Updates also required for fluree/ledger for this fix.