### PR TITLE
FC-1036 add prop for bigdec encoding in json

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:mvn/version "1.0.0-rc19"}
+        com.fluree/db {:mvn/version "1.0.0-rc20"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
-        com.fluree/db {:mvn/version "1.0.0-rc20"}
+        com.fluree/db {:mvn/version "1.0.0-rc21"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/resources/fluree_sample.properties
+++ b/resources/fluree_sample.properties
@@ -12,6 +12,12 @@
 # Can be dev, query or ledger (defaults to query).
 fdb-mode=dev
 
+# BigDecimals are not currently handled out-of-the-box by
+# JavaScript applications.  This setting determines whether
+# or not to encode java.Math.BigDecimal values as strings
+# for query results, etc.  The default is true.
+fdb-json-bigdec-string=true
+
 ############################################################
 ### Ledger Group Settings
 

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -993,7 +993,7 @@
   (if-not (:enabled opts)
     (do (log/info "Web server disabled, not starting.")
         nil)
-    (let [{:keys [port open-api system debug-mode?]} opts
+    (let [{:keys [port open-api system debug-mode? json-bigdec-string]} opts
           _           (log/info (str "Starting web server on port: " port (if open-api " with an open API." "with a closed API.")))
           _           (log/info "")
           _           (log/info (str "http://localhost:" port))
@@ -1003,6 +1003,7 @@
                                     :debug-mode? debug-mode?
                                     :open-api open-api)
           server-proc (try
+                        (json/encode-BigDecimal-as-string json-bigdec-string)
                         (http/start-server (make-handler system*) {:port port})
                         (catch BindException _
                           (log/error (str "Cannot start. Port binding failed, address already in use. Port: " port "."))

--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -26,6 +26,7 @@
    :fdb-license-key              nil
    :fdb-consensus-type           "raft"                     ;; raft
    :fdb-encryption-secret        nil                        ;; Text encryption secret for encrypting data at rest and in transit
+   :fdb-json-bigdec-string       true                       ;; encode BigDecimal numbers as a string for json.stringify
 
    :fdb-group-config-path        "./"
    :fdb-group-private-key        nil
@@ -690,6 +691,8 @@
                    :enabled     webserver?
                    :debug-mode? debug-mode?
                    :open-api    (-> settings :fdb-api-open env-boolean)
+                   :json-bigdec-string
+                                (-> settings :fdb-json-bigdec-string env-boolean)
                    :meta        {:hostname hostname}}
      ;:version  fdb-version
 


### PR DESCRIPTION
Should be reviewed with [PR#66](https://github.com/fluree/db/pull/66) on db. Added property to handle default behavior for bigdec encoding as non-JavaScript clients (e.g., python, c#) seem to handle BigDecimals without conversion to string.