### PR TITLE
FC-1165 re-enabled close-all-sessions

### DIFF
--- a/src/fluree/db/peer/websocket.clj
+++ b/src/fluree/db/peer/websocket.clj
@@ -33,7 +33,7 @@
   "Cleanup when a websocket is closed."
   [ws-id producer-chan]
   (try
-    ;(close-all-sessions ws-id)
+    (close-all-sessions ws-id)
     (async/close! producer-chan)
     (swap! ws-connections (fn [ws-state]
                             ;(when-let [send-chan (get-in ws-state [ws-id :send-chan])]


### PR DESCRIPTION
Re-enabled close-all-sessions when a websocket is closed with a client.