### PR TITLE
Improve :dev :test profiles in the REPL and w/r/t logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ target/fluree-ledger.jar: resources/adminUI $(SOURCES) $(RESOURCES)
 jar: target/fluree-ledger.jar
 
 test:
-	clojure -M:test
+	clojure -M:test:runner
 
 target/fluree-ledger.standalone.jar: resources/adminUI $(SOURCES) $(RESOURCES)
 	clojure -X:uberjar

--- a/deps.edn
+++ b/deps.edn
@@ -43,11 +43,11 @@
   :runner
   {:extra-deps {com.cognitect/test-runner
                 {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                 :sha "b6b3193fcc42659d7e46ecd1884a228993441182"}}
+                 :sha "62ef1de18e076903374306060ac0e8a752e57c86"}}
    :main-opts ["-m" "cognitect.test-runner"]}
 
   :jar
-  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.206"}}
+  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.245"}}
    :exec-fn hf.depstar/jar
    :exec-args {:jar "target/fluree-ledger.jar"
                :group-id :mvn/group-id
@@ -56,7 +56,7 @@
                :sync-pom true}}
 
   :uberjar
-  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.206"}}
+  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.245"}}
    :exec-fn hf.depstar/uberjar
    :exec-args {:jar "target/fluree-ledger.standalone.jar"
                :aot true

--- a/deps.edn
+++ b/deps.edn
@@ -38,8 +38,10 @@
                "-e" "(in-ns,'user)"]}
 
   :test
-  {:extra-paths ["test"]
-   :extra-deps {com.cognitect/test-runner
+  {:extra-paths ["test"]}
+
+  :runner
+  {:extra-deps {com.cognitect/test-runner
                 {:git/url "https://github.com/cognitect-labs/test-runner.git"
                  :sha "b6b3193fcc42659d7e46ecd1884a228993441182"}}
    :main-opts ["-m" "cognitect.test-runner"]}

--- a/deps.edn
+++ b/deps.edn
@@ -41,7 +41,8 @@
   {:extra-paths ["test"]}
 
   :runner
-  {:extra-deps {com.cognitect/test-runner
+  {:extra-paths ["test-resources"]
+   :extra-deps {com.cognitect/test-runner
                 {:git/url "https://github.com/cognitect-labs/test-runner.git"
                  :sha "62ef1de18e076903374306060ac0e8a752e57c86"}}
    :main-opts ["-m" "cognitect.test-runner"]}

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--Turn off logging during tests.-->
+<configuration scan="true" />
+
+<!-- If you need to debug something test-related with logs, delete this file temporarily
+     or edit/replace it to do the logging you want. -->

--- a/test/logback-test.xml
+++ b/test/logback-test.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<!--Turn off logging during tests.-->
-<configuration />
-
-<!--If you need to debug something test-related with logs, delete this file temporarily.-->


### PR DESCRIPTION
As discussed in a recent internal Slack thread, this does the following:

1. Splits the test runner into its own `:runner` alias. `make test` now invokes `clojure -M:test:runner` to bring in both. This allows pulling in the `:test` alias in a REPL w/o also bringing in the runner.
1. Moves the `test/logback-test.xml` file to `test-resources` and only adds `test-resources` to the classpath in the `:runner` alias. This leaves the logging config alone when just using the `:test` alias without `:runner` allowing e.g. a REPL pulling in `:dev` & `:test` to use `dev/logback.xml`.

This seemed like a simple, quick starting place. Let me know if you'd like any other changes to how this works.