### PR TITLE
FC-1191 fix security issue with websocket in closed-api mode

### DIFF
--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -209,10 +209,15 @@
                   (async/close! producer-chan))
          :ping (async/put! producer-chan [:pong req-id true nil])
 
-         :settings (success! {:open-api?         (-> system :group :open-api)
-                              :password-enabled? (pw-auth/password-enabled? (:conn system))
-                              :jwt-secret        (-> system :conn :meta :password-auth :secret
-                                                     (ab-core/byte-array-to-base :hex))})
+         :settings (let [open-api? (-> system :group :open-api)
+                         has-auth? (-> (get-in @subscription-auth [ws-id])
+                                       (as-> wsm (reduce-kv (fn [res _ val] (if (map? val) (into res (vals val)) res)) [] wsm))
+                                       seq)]
+                     (cond-> {:open-api?          open-api?
+                              :password-enabled?  (-> system :conn pw-auth/password-enabled?)}
+                             (or open-api? has-auth?) (assoc :jwt-secret (-> system :conn :meta :password-auth :secret
+                                                                         (ab-core/byte-array-to-base :hex)))
+                             true success!))
 
          :cmd (success! (process-command system arg))
 

--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -250,6 +250,10 @@
                                                         auth-or-jwt)
                                               root-db (async/<!! (fdb/db (:conn system) ledger))]
                                           (async/<!! (dbproto/-subid root-db auth-id))))
+                          _           (when-not (or auth open-api?)
+                                        (throw (ex-info "To access the server, either open-api must be true or a valid auth must be provided."
+                                                        {:status 401
+                                                         :error  :db/invalid-request})))
 
                           dbv         (session/resolve-ledger (:conn system) ledger)
                           [network dbid] dbv


### PR DESCRIPTION
Fixed the following:

* "settings" command checks for subscription auth in closed-api mode; does not return secret unless authenticated
* "subscribe" command checks for auth in closed-api mode; throws an exception when an auth/jwt is not provided