### PR TITLE
FC-1175: Fix S3 data recovery

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -18,12 +18,12 @@
 
         ;; web server
         aleph-middleware/aleph-middleware {:mvn/version "0.2.0"}
-        ring/ring-core {:mvn/version "1.9.3"}
+        ring/ring-core {:mvn/version "1.9.4"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
         compojure/compojure {:mvn/version "1.6.2"}
 
         ;; logging
-        ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}
+        ch.qos.logback/logback-classic {:mvn/version "1.2.5"}}
 
  :paths ["src" "resources"]
  :aliases
@@ -44,7 +44,7 @@
   {:extra-paths ["test-resources"]
    :extra-deps {com.cognitect/test-runner
                 {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                 :sha "f597341b6ca7bb4cf027e0a34a6710ca9cb969da"}}
+                 :sha "4e7e1c0dfd5291fa2134df052443dc29695d8cbe"}}
    :main-opts ["-m" "cognitect.test-runner"]}
 
   :jar
@@ -84,5 +84,5 @@
    :main-opts ["-m" "antq.core" "--skip=github-action"]}
 
   :clj-kondo
-  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.06.18"}}
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.07.28"}}
    :main-opts ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}}}

--- a/src/fluree/db/ledger/storage/s3store.clj
+++ b/src/fluree/db/ledger/storage/s3store.clj
@@ -18,6 +18,14 @@
   (str (bucket->url bucket) k))
 
 
+(defn strip-path-prefix
+  "Strip path prefix from key"
+  [path key]
+  (if (str/starts-with? key path)
+    (-> key (str/replace-first path "") (str/replace #"^/" ""))
+    key))
+
+
 (defn read
   "Returns a byte array of the data under key `k` (converted to a UNIX-style
   path with key->unix-path) of this store's S3 bucket. Returns an exception if
@@ -88,26 +96,37 @@
          (write conn base-path key data))))))
 
 
-(defn list
-  "Returns a sequence of data maps with keys `#{:name :size :url}` representing
-  the files in this store's S3 bucket."
-  [{:keys [client bucket] :as conn} & [path]]
-  (log/debug "Listing files in bucket" bucket "at" (or path "/"))
-  (let [req        {:op      :ListObjectsV2
-                    :request {:Bucket bucket}}
-        req        (if path
-                     (assoc-in req [:request :Prefix] path)
-                     req)
-        resp       (aws/invoke client req)]
+(defn- s3-list
+  [{:keys [client bucket]} path]
+  (let [base-req {:op      :ListObjectsV2
+                  :request {:Bucket bucket}}
+        req (if (= path "/")
+              base-req
+              (assoc-in base-req [:request :Prefix] path))
+        resp (aws/invoke client req)]
     (if (:cognitect.anomalies/category resp)
       (if (:cognitect.aws.client/throwable resp)
         resp
         (ex-info "S3 list failed" {:response resp}))
-      (let [objects    (:Contents resp)
-            bucket-url (partial key->url conn)]
-        (map (fn [{key :Key, size :Size}]
-               {:name key, :url (bucket-url key), :size size})
-             objects)))))
+      (:Contents resp))))
+
+
+(defn list
+  "Returns a sequence of data maps with keys `#{:name :size :url}` representing
+  the files in this store's S3 bucket."
+  [{:keys [bucket] :as conn} & [path]]
+  (let [path' (or path "/")]
+    (log/debug "Listing files in bucket" bucket "at" path')
+    (let [objects (s3-list conn path')
+          bucket-url (partial key->url conn)
+          result (map (fn [{key :Key, size :Size}]
+                        {:name (strip-path-prefix path' key)
+                         :url  (bucket-url key)
+                         :size size})
+                      objects)]
+      (log/debug (format "Objects found in %s bucket at %s: %s"
+                           bucket path' (pr-str result)))
+      result)))
 
 
 (defn connection-storage-list
@@ -126,8 +145,8 @@
   (let [s3-key (key->unix-path base-path k)]
     (log/debug "Checking for existence of" s3-key "in bucket" (:bucket conn))
     (->> base-path
-         (list conn)
-         (map :name)
+         (s3-list conn)
+         (map :Key)
          (some #{s3-key})
          boolean)))
 


### PR DESCRIPTION
This fixes the startup data recovery from snapshot when there is no more local raft state (e.g. ephemeral storage went away). Fixes FC-1175.