### PR TITLE
FC-1209: feature/update db dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase {:mvn/version "3.2.1"}
-        com.fluree/db {:mvn/version "1.0.0-rc24"}
+        com.fluree/db {:mvn/version "1.0.0-rc25"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 


### PR DESCRIPTION
Update db dependency to version 1.0.0-rc25 to pick up full text index bug fixes there.