### PR TITLE
FC-1210 Fix for transact error handling and db cache update

### DIFF
--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -148,7 +148,7 @@
                                        (:dbid session) (dissoc block-result :db-before :db-after)))]
               (if (true? new-block-resp)
                 (let [res (<? (indexing/index* session {:remove-preds remove-preds*}))]
-                  (when-not res
+                  #_(when-not res
                     (let [new-db-ch (async/promise-chan)]
                       (async/put! new-db-ch (:db-after block-result))
                       (session/cas-db! session db-before-ch new-db-ch)))

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -11,8 +11,7 @@
             [fluree.db.constants :as const]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
-            [fluree.db.ledger.transact.json :as tx-json]
-            [clojure.core.async :as async]))
+            [fluree.db.ledger.transact.json :as tx-json]))
 
 
 (defn valid-authority?
@@ -147,11 +146,8 @@
                                        (-> session :conn :group) (:network session)
                                        (:dbid session) (dissoc block-result :db-before :db-after)))]
               (if (true? new-block-resp)
-                (let [res (<? (indexing/index* session {:remove-preds remove-preds*}))]
-                  #_(when-not res
-                    (let [new-db-ch (async/promise-chan)]
-                      (async/put! new-db-ch (:db-after block-result))
-                      (session/cas-db! session db-before-ch new-db-ch)))
+                (do
+                  (<? (indexing/index* session {:remove-preds remove-preds*}))
                   block-result)
                 (do
                   (log/warn "Proposed block was not accepted by the network because: "

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -11,7 +11,8 @@
             [fluree.db.constants :as const]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
-            [fluree.db.ledger.transact.json :as tx-json]))
+            [fluree.db.ledger.transact.json :as tx-json]
+            [clojure.core.async :as async]))
 
 
 (defn valid-authority?

--- a/src/fluree/db/ledger/transact/error.clj
+++ b/src/fluree/db/ledger/transact/error.clj
@@ -111,11 +111,10 @@
           hash-flake       (tx-meta/generate-hash-flake flakes tx-state)
           all-flakes       (conj flakes hash-flake)
           fast-forward-db? (:tt-id db)
-          db-after         (->> (if fast-forward-db?
-                                  (<? (dbproto/-forward-time-travel db all-flakes))
-                                  (<? (dbproto/-with-t db all-flakes)))
-                                dbproto/-rootdb
-                                tx-util/make-candidate-db)
+          current-db       (if fast-forward-db?
+                             (<? (dbproto/-forward-time-travel db all-flakes))
+                             (<? (dbproto/-with-t db all-flakes)))
+          db-after         (-> current-db dbproto/-rootdb tx-util/make-candidate-db)
           tx-bytes         (- (get-in db-after [:stats :size]) (get-in db [:stats :size]))]
       {:error        error
        :t            t

--- a/src/fluree/db/ledger/transact/error.clj
+++ b/src/fluree/db/ledger/transact/error.clj
@@ -99,7 +99,7 @@
   "This should not happen, but somehow the cmd-date could not be parsed.
   Because of this we don't have basic information about the transaction
   but we still want to record the tx. We'll assume cmd-data is a string
-  and instead of extracting a command out of it (which didn't work"
+  and instead of extracting a command out of it (which didn't work)"
   [e db cmd-data t]
   (go-try
     (let [{:keys [message status error]} (decode-exception e)
@@ -111,10 +111,9 @@
           hash-flake       (tx-meta/generate-hash-flake flakes tx-state)
           all-flakes       (conj flakes hash-flake)
           fast-forward-db? (:tt-id db)
-          current-db       (if fast-forward-db?
+          db-after         (if fast-forward-db?
                              (<? (dbproto/-forward-time-travel db all-flakes))
                              (<? (dbproto/-with-t db all-flakes)))
-          db-after         (-> current-db dbproto/-rootdb tx-util/make-candidate-db)
           tx-bytes         (- (get-in db-after [:stats :size]) (get-in db [:stats :size]))]
       {:error        error
        :t            t

--- a/src/fluree/db/ledger/transact/error.clj
+++ b/src/fluree/db/ledger/transact/error.clj
@@ -34,9 +34,11 @@
           hash-flake       (tx-meta/generate-hash-flake flakes tx-state)
           all-flakes       (conj flakes hash-flake)
           fast-forward-db? (:tt-id db-before)
-          db-after         (if fast-forward-db?
-                             (<? (dbproto/-forward-time-travel db-before all-flakes))
-                             (<? (dbproto/-with-t db-before all-flakes)))
+          db-after         (->> (if fast-forward-db?
+                                  (<? (dbproto/-forward-time-travel db-before all-flakes))
+                                  (<? (dbproto/-with-t db-before all-flakes)))
+                                dbproto/-rootdb
+                                tx-util/make-candidate-db)
           tx-bytes         (- (get-in db-after [:stats :size]) (get-in db-before [:stats :size]))]
       {:error        error
        :t            t
@@ -80,9 +82,11 @@
           hash-flake       (tx-meta/generate-hash-flake flakes tx-state)
           all-flakes       (conj flakes hash-flake)
           fast-forward-db? (:tt-id db-before)
-          db-after         (if fast-forward-db?
-                             (<? (dbproto/-forward-time-travel db-before all-flakes))
-                             (<? (dbproto/-with-t db-before all-flakes)))
+          db-after         (->> (if fast-forward-db?
+                                  (<? (dbproto/-forward-time-travel db-before all-flakes))
+                                  (<? (dbproto/-with-t db-before all-flakes)))
+                                dbproto/-rootdb
+                                tx-util/make-candidate-db)
           tx-bytes         (- (get-in db-after [:stats :size]) (get-in db-before [:stats :size]))]
       (assoc return-map :error error
                         :errors sorted-errors
@@ -111,9 +115,11 @@
           hash-flake       (tx-meta/generate-hash-flake flakes tx-state)
           all-flakes       (conj flakes hash-flake)
           fast-forward-db? (:tt-id db)
-          db-after         (if fast-forward-db?
-                             (<? (dbproto/-forward-time-travel db all-flakes))
-                             (<? (dbproto/-with-t db all-flakes)))
+          db-after         (->> (if fast-forward-db?
+                                  (<? (dbproto/-forward-time-travel db all-flakes))
+                                  (<? (dbproto/-with-t db all-flakes)))
+                                dbproto/-rootdb
+                                tx-util/make-candidate-db)
           tx-bytes         (- (get-in db-after [:stats :size]) (get-in db [:stats :size]))]
       {:error        error
        :t            t


### PR DESCRIPTION
fix for the following issues:

- In closed-api mode, the transaction information was not being returned.  This was caused by the db cache not being updated unless an index required an update
- In closed-api mode, query results were not updated (or were blank). This also was caused by the db cache not being updated unless an index required an update
- When a transaction error occurred (e.g., invalid auth), queries returned no results. This was caused in error handling when the returned db only contained error flakes was not converted into a 'candidate' db