### PR TITLE
FC-1223 parse flake to retrieve previous hash

### DIFF
--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -38,10 +38,10 @@
           block         (inc (:block db-current))
           block-instant (util/current-time-millis)
           before-t      (:t db-current)
-          prev-hash     (-> (query-range/index-range db-current :spot = [before-t const/$_block:hash])
-                            <?
-                            first
-                            .-o) ; get hash (object) from flake
+          prev-hash     (some-> (query-range/index-range db-current :spot = [before-t const/$_block:hash])
+                                <?
+                                first
+                                .-o) ; get hash (object) from flake
           _             (when-not prev-hash
                           (throw (ex-info (str "Unable to retrieve previous block hash. Unexpected error.")
                                           {:status 500

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -38,7 +38,10 @@
           block         (inc (:block db-current))
           block-instant (util/current-time-millis)
           before-t      (:t db-current)
-          prev-hash     (first (<? (query-range/index-range db-current :spot = [before-t const/$_block:hash])))
+          prev-hash     (-> (query-range/index-range db-current :spot = [before-t const/$_block:hash])
+                            <?
+                            first
+                            .-o) ; get hash (object) from flake
           _             (when-not prev-hash
                           (throw (ex-info (str "Unable to retrieve previous block hash. Unexpected error.")
                                           {:status 500


### PR DESCRIPTION
fixed issue in build-block where the previous hash was set a flake, versus the hash it contained.

the unit tests didn't pick this up, because in-memory db doesn't validate value-types against a map like avro does.