### PR TITLE
FC-1231 When corrupt raft state, check for missing blocks

### DIFF
--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -9,12 +9,14 @@
             [fluree.db.serde.avro :as avro]
             [fluree.db.event-bus :as event-bus]
             [fluree.db.ledger.consensus.tcp :as ftcp]
-            [fluree.db.util.async :refer [go-try <??]]
+            [fluree.db.util.async :refer [go-try <? <??]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto :refer [TxGroup]]
             [fluree.db.ledger.consensus.update-state :as update-state]
             [fluree.db.ledger.txgroup.monitor :as group-monitor]
             [fluree.db.ledger.consensus.dbsync2 :as dbsync2]
-            [fluree.crypto :as crypto])
+            [fluree.crypto :as crypto]
+            [fluree.db.ledger.storage :as ledger-storage]
+            [fluree.db.constants :as const])
   (:import (java.util UUID)))
 
 
@@ -237,7 +239,8 @@
                    ;; (a) the submission-server is currently the worker for the network
                    ;; (b) the block-id is exactly one block increment from the previous block
                    ;; if it contains a command-type of :new-db, we also establish a new db record
-                   :new-block (let [[_ network dbid block-map submission-server] command
+                   :new-block (let [_               (log/warn "Received new block data: " command)
+                                    [_ network dbid block-map submission-server] command
                                     {:keys [block txns cmd-types]} block-map
                                     txids           (keys txns)
                                     file-key        (storage/ledger-block-key network dbid block)
@@ -708,6 +711,37 @@
     (acquire-lease-async raft [:leases :servers this-server] this-server expire-ms)))
 
 
+(defn check-if-newer-blocks-on-disk
+  "In the case of startup as a leader, but possibly old raft state, we check to see
+  if there are newer blocks on disk that were added after the raft state we started with.
+
+  If so, it will broadcast those blocks out."
+  [{:keys [group] :as conn}]
+  (go-try
+    (let [current-state @(:state-atom group)]
+      (when-let [ledgers (not-empty (txproto/ledger-list* current-state))]
+        (doseq [[network dbid] ledgers]
+          (let [latest-block (txproto/block-height* current-state network dbid)]
+
+            (log/debug "Raft startup - latest block: " [network dbid] latest-block)
+            (loop [next-block (inc latest-block)]
+              (when (<? (ledger-storage/block-exists? conn network dbid next-block))
+                (let [block-data  (<? (storage/read-block conn network dbid next-block))
+                      ;; incoming raft event expects a map of txns in block, with txid being keys. and :cmd-types
+                      ;; would error in raft if these are not included, recreate from block data
+                      block-data* (assoc block-data :cmd-types #{:tx}
+                                                    :txns (->> (:flakes block-data)
+                                                               (keep #(when (= const/$_tx:id (.-p %))
+                                                                        [(.-o %) nil]))
+                                                               (into {})))]
+
+                  (log/info (str "Ledger " network "/" dbid
+                                 " has block file(s) beyond raft known block height of "
+                                 latest-block ". Found block: " next-block))
+                  (<? (txproto/propose-new-block-async group network dbid block-data*)))
+                (recur (inc next-block))))))))))
+
+
 (defn raft-start-up
   [group conn system* shutdown _]
   (async/go
@@ -737,12 +771,18 @@
 
 
            (when (async/<! (is-leader?-async group))
-             (when (empty? (txproto/get-shared-private-key group))
-               (log/info "Brand new Fluree instance, establishing default shared private key.")
-               ;; TODO - check environment to see if a private key was supplied
-               (let [private-key (or (:tx-private-key conn)
-                                     (:private (crypto/generate-key-pair)))]
-                 (txproto/set-shared-private-key (:group conn) private-key))))
+             (let [new-instance? (empty? (txproto/get-shared-private-key group))]
+               (if new-instance?
+                 (do
+                   (log/info "Brand new Fluree instance, establishing default shared private key.")
+                   ;; TODO - check environment to see if a private key was supplied
+                   (let [private-key (or (:tx-private-key conn)
+                                         (:private (crypto/generate-key-pair)))]
+                     (txproto/set-shared-private-key (:group conn) private-key)))
+                 ;; not a new instance, but just started as leader - could have old
+                 ;; raft files that don't have latest blocks. Check, and potentially add latest block
+                 ;; files to network.
+                 (<? (check-if-newer-blocks-on-disk conn)))))
 
 
            ;; monitor state changes to kick of transactions for any queues

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -239,8 +239,7 @@
                    ;; (a) the submission-server is currently the worker for the network
                    ;; (b) the block-id is exactly one block increment from the previous block
                    ;; if it contains a command-type of :new-db, we also establish a new db record
-                   :new-block (let [_               (log/warn "Received new block data: " command)
-                                    [_ network dbid block-map submission-server] command
+                   :new-block (let [[_ network dbid block-map submission-server] command
                                     {:keys [block txns cmd-types]} block-map
                                     txids           (keys txns)
                                     file-key        (storage/ledger-block-key network dbid block)

--- a/src/fluree/db/ledger/storage.clj
+++ b/src/fluree/db/ledger/storage.clj
@@ -1,6 +1,9 @@
 (ns fluree.db.ledger.storage
   (:require [clojure.string :as str]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [fluree.db.ledger.util :as util :refer [go-try <?]]
+            [fluree.db.util.log :as log]
+            [fluree.db.storage.core :as storage])
   (:import (java.io File)))
 
 (defn key->unix-path
@@ -17,3 +20,60 @@
          split-key (str/split key #"_")
          file      (apply io/file base-path split-key)]
      (.toString ^File file))))
+
+
+(defn block-storage-path
+  "For a ledger server, will return the relative storage path it is using for blocks for a given ledger."
+  [network dbid]
+  (io/file network dbid "block"))
+
+
+(defn block-file?
+  "Given a file map as output by :storage-list function on the connection,
+  returns true if it matches the block file format.
+
+  This is used for directory listings that presume all the files should be block files,
+  but possible end-user put a different file in there manually."
+  [file-map]
+  (-> file-map
+      :name
+      (re-matches #".+/[0-9]+\.fdbd$")))
+
+
+(defn block-files
+  "Returns async chan containing single list of block files on disk for a given ledger"
+  [{:keys [storage-list] :as conn} network dbid]
+  (go-try
+    (->> (block-storage-path network dbid)
+         storage-list
+         <?
+         (filter block-file?))))
+
+
+(defn- block-file->block-long
+  "Takes a block file in format as returned by :storage-list function on the connection
+  and returns a long integer block if the file size is > 0 and it matches the block file
+  format."
+  [block-file-map]
+  (when (> (:size block-file-map) 0)
+    (some->> (:name block-file-map)
+             (re-find #"\D?([0-9]+)\.fdbd$")
+             ^String second
+             Long/parseLong)))
+
+(defn blocks
+  "Returns a list of blocks on disk as long integers whose file sizes are > 0
+  and match the prescribed block file path format."
+  [{:keys [storage-list] :as conn} network dbid]
+  (go-try
+    (->> (block-storage-path network dbid)
+         storage-list
+         <?
+         (keep block-file->block-long))))
+
+
+(defn block-exists?
+  "Returns core async channel with true if block for given ledger exists on disk."
+  [{:keys [storage-exists] :as conn} network dbid block]
+  (-> (storage/ledger-block-key network dbid block)
+      storage-exists))

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -124,8 +124,9 @@
          memory?        (= :memory storage-type)
          group          (let [group-opts (:group config)]
                           (if transactor?
+                            (txgroup/start group-opts consensus-type join?)
                             ;; TODO - currently if query-peer, we use a dummy group obj. Change this?
-                            (txgroup/start group-opts consensus-type join?) group-opts))
+                            group-opts))
 
          remote-writer  (fn [k data]
                           (txproto/storage-write-async group k data))


### PR DESCRIPTION
If a raft file and/or snapshot becomes corrupt and deleted, a prior state will be restored. If there were new blocks created since the last non-corrupt file, those will be on disk but not reflected in raft state.

This fix checks for newer blocks and will re-add them into raft state under the following conditions:
1) At ledger server startup only
2) When starting server is also immediately elected the leader

These conditions will always happen in a one-node ledger server, but this check will not happen if there is an existing leader.