### PR TITLE
FC-1193 Fix/collection spec when retraction

### DIFF
--- a/src/fluree/db/ledger/transact/validation.clj
+++ b/src/fluree/db/ledger/transact/validation.clj
@@ -364,7 +364,7 @@
     (try
       (let [subject-flakes (get-in @validate-fn [:c-spec sid])
             has-adds?      (some (fn [^Flake flake] (when (true? (.-op flake)) true)) subject-flakes) ;; stop at first `true` .-op
-            deleted?       (or (not has-adds?)
+            deleted?       (or (false? has-adds?)  ; has-adds? is nil when not found
                                (empty? (<? (query-range/index-range @db-after :spot = [sid]))))]
         (if deleted?
           true

--- a/test/fluree/db/ledger/docs/smart_functions/collection_spec.clj
+++ b/test/fluree/db/ledger/docs/smart_functions/collection_spec.clj
@@ -20,14 +20,31 @@
    (is (= "Collection spec failed for: person. A person is required to have a fullName."
           test-resp))))
 
+(deftest full-name-req-test-retractions
+  (let [add-person  [{:_id "person", :handle "deleteMe", :fullName "To Be Deleted"}]
+        _ (async/<!! (fdb/transact-async (basic/get-conn) test/ledger-chat add-person))
+        test-spec-1 [{:_id ["person/handle" "deleteMe" ] :fullName nil}]
+        test-resp-1 (-> (async/<!! (fdb/transact-async (basic/get-conn) test/ledger-chat test-spec-1))
+                        test/safe-Throwable->map :cause)
+        test-spec-2 [{:_id ["person/handle" "deleteMe" ] :_action "delete"}]
+        test-resp-2 (async/<!! (fdb/transact-async (basic/get-conn) test/ledger-chat test-spec-2))]
+
+    (is (= "Collection spec failed for: person. A person is required to have a fullName."
+           test-resp-1))
+    (is (map? test-resp-2))
+    (is (= 200 (:status test-resp-2)))
+    (is (= 8 (-> test-resp-2 :flakes count)))))
+
 (deftest collection-spec-test
-  (full-name-req-test))
+  (full-name-req-test)
+  (full-name-req-test-retractions))
 
 (deftest tests-independent
   (basic/add-collections*)
   (basic/add-predicates)
   (basic/add-sample-data)
   (basic/graphql-txn)
-  (full-name-req-test))
+  (full-name-req-test)
+  (full-name-req-test-retractions))
 
 


### PR DESCRIPTION
Fixed check for when to apply collection-spec for retraction and added unit tests.  The check for additions came back nil (versus false) when there are no additions.  
