### PR TITLE
FC-1239 Fix/tx ex reporting

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase {:mvn/version "3.2.1"}
-        com.fluree/db {:mvn/version "1.0.0-rc25"}
+        com.fluree/db {:git/url "https://github.com/fluree/db.git"
+                       :sha "9debad6a99c03a91f1f678bdee05385c5fa269e4"}
         com.fluree/raft {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto {:mvn/version "0.3.5"}
 

--- a/src/fluree/db/ledger/consensus/none.clj
+++ b/src/fluree/db/ledger/consensus/none.clj
@@ -105,7 +105,7 @@
 
                    :get-in (update-state/get-in* entry state-atom)
 
-                   :dissoc-in (update-state/assoc-in* entry state-atom)
+                   :dissoc-in (update-state/dissoc-in* entry state-atom)
 
                    ;; Will replace current val at key sequence only if existing val is = compare value at
                    ;; compare key sequence.

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -327,7 +327,7 @@
                    :get-in (update-state/get-in* command state-atom)
 
                    ;; Returns true if there was an existing value removed, else false.
-                   :dissoc-in (update-state/assoc-in* command state-atom)
+                   :dissoc-in (update-state/dissoc-in* command state-atom)
 
                    ;; acquires lease, stored at specified ks (a more elaborate cas). Uses local clock
                    ;; to help combat clock skew. Will only allow a single lease at specified ks.

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -228,6 +228,20 @@
   (reset! state-change-fn-atom {}))
 
 
+(defn rejected-block-handler
+  "If a block is rejected for some reason, handles exception and logging."
+  [state-atom command error-msg]
+  (let [[_ network dbid block-map submission-server] command
+        {:keys [block txns cmd-types]} block-map
+        txids (keys txns)]
+    (swap! state-atom
+           (fn [state]
+             (reduce (fn [s txid] (update-state/dissoc-in s [:cmd-queue network txid])) state txids)))
+    (ex-info (str " --------------- BLOCK REJECTED! " error-msg)
+             {:error  :db/invalid-block
+              :status 500})))
+
+
 (defn state-machine
   [_ state-atom storage-read storage-write]
   (fn [command _]
@@ -254,7 +268,7 @@
                                   (update-state/register-new-dbs txns state-atom block-map))
 
                                 (if (and is-next-block? server-allowed?)
-                                  (do
+                                  (try
                                     ;; write out block data - todo: ensure raft shutdown happens successfully if write fails
                                     (storage-write file-key (avro/serialize-block block-map))
 
@@ -270,23 +284,19 @@
                                     ;; publish new-block event
                                     (event-bus/publish :block [network dbid] block-map)
                                     ;; return success!
-                                    true)
-                                  (do
-                                    (swap! state-atom
-                                           (fn [state]
-                                             (reduce (fn [s txid] (update-state/dissoc-in s [:cmd-queue network txid])) state txids)))
-
-                                    (ex-info (str " --------------- BLOCK REJECTED! "
-                                                  (if (not is-next-block?)
-                                                    (str "Blocks out of order. Block " block " should be one more than current block: " current-block)
-                                                    (str "Server: " submission-server " is not registered as current worker for this network: " network
-                                                         ". That server is: " (get-in @state-atom [:_work :networks network])))
-                                                  (pr-str {:server-allowed server-allowed?
-                                                           :is-next-block? is-next-block?
-                                                           :command        command
-                                                           :state-dump     @state-atom}))
-                                             {:error  :db/invalid-block
-                                              :status 500}))))
+                                    true
+                                    (catch Exception e
+                                      (rejected-block-handler state-atom command
+                                                              (str "Exception attempting to write block: " (.getMessage e)))))
+                                  (rejected-block-handler state-atom command
+                                                          (str (if (not is-next-block?)
+                                                                 (str "Blocks out of order. Block " block " should be one more than current block: " current-block)
+                                                                 (str "Server: " submission-server " is not registered as current worker for this network: " network
+                                                                      ". That server is: " (get-in @state-atom [:_work :networks network])))
+                                                               (pr-str {:server-allowed server-allowed?
+                                                                        :is-next-block? is-next-block?
+                                                                        :command        command
+                                                                        :state-dump     @state-atom})))))
 
 
                    ;; stages a new db to be created

--- a/src/fluree/db/ledger/consensus/update_state.clj
+++ b/src/fluree/db/ledger/consensus/update_state.clj
@@ -16,6 +16,8 @@
     (update-in map (butlast ks) dissoc (last ks))))
 
 (defn assoc-in*
+  "Handles assoc-in commands. If assoc-in is called without a value to associate into,
+  treats operation as a dissoc-in operation."
   [command state-atom]
   (let [[_ ks v] command]
     (if (nil? v)
@@ -29,12 +31,22 @@
     (get-in @state-atom ks)))
 
 (defn dissoc-in
+  "Like Clojure's dissoc, but takes a key sequence to enable dissoc within a nested map."
   [map ks]
   (let [ks*        (butlast ks)
         dissoc-key (last ks)]
     (if ks*
       (update-in map ks* dissoc dissoc-key)
       (dissoc map dissoc-key))))
+
+(defn dissoc-in*
+  "Executes incoming :dissoc-in command against state atom.
+  Like Clojure's dissoc, but takes a key sequence to enable
+  dissoc within a nested map."
+  [command state-atom]
+  (let [[_ ks] command]
+    (let [res (swap! state-atom dissoc-in ks)]
+      res)))
 
 (defn cas-in
   [command state-atom]

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -11,7 +11,7 @@
             [fluree.db.constants :as const]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
-            [fluree.db.ledger.transact.json :as tx-json]
+            [fluree.db.ledger.transact.core :as tx-core]
             [fluree.db.query.range :as query-range]))
 
 
@@ -57,7 +57,7 @@
              txns             {}
              remove-preds-acc #{}]
         (let [start-time    (util/current-time-millis)
-              tx-result     (<? (tx-json/transact db-root cmd-data next-t block-instant))
+              tx-result     (<? (tx-core/transact db-root cmd-data next-t block-instant))
               {:keys [db-after bytes fuel flakes tempids auth authority status error errors
                       hash remove-preds]} tx-result
               block-bytes*  (+ block-bytes bytes)

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -7,12 +7,13 @@
             [fluree.db.ledger.indexing :as indexing]
             [fluree.db.session :as session]
             [fluree.db.util.tx :as tx-util]
-            [fluree.db.query.fql :as fql]
             [fluree.db.constants :as const]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
             [fluree.db.ledger.transact.core :as tx-core]
-            [fluree.db.query.range :as query-range]))
+            [fluree.db.query.range :as query-range]
+            [clojure.core.async :as async])
+  (:import (fluree.db.flake Flake)))
 
 
 (defn valid-authority?
@@ -23,136 +24,236 @@
                       {:status 403 :error :db/invalid-auth})) true)))
 
 
+(defn ->block-map
+  "Creates initial block map that ultimately gets returned after block completed."
+  [db prev-hash]
+  {:db-before    db
+   :db-after     nil
+   :cmd-types    #{}
+   :block        (inc (:block db))                          ;; block number
+   :t            (:t db)                                    ;; updated with every tx within block
+   :before-t     (:t db)                                    ;; never updated, t before block
+   :hash         nil                                        ;; final block hash
+   :sigs         nil                                        ;; signature(s) of ledgers that seal the block
+   :instant      (util/current-time-millis)
+   :flakes       (flake/sorted-set-by flake/cmp-flakes-block)
+   :block-bytes  0
+   :fuel         0
+   :txns         {}
+   :prev-hash    prev-hash
+   :remove-preds #{}})
+
+
+(defn merge-tx-into-block
+  "Merges transaction results into the block map that ultimately gets returned.
+
+  The block itself also creates a transaction on top of the other transactions, and
+  also uses this function to update the db, flakes and bytes. The block tx does not
+  have a txid, and intentionally will not exist in the :txns map."
+  [block-map tx-result]
+  (let [{:keys [db-after bytes fuel flakes remove-preds type t txid hash]} tx-result]
+    (-> block-map
+        (assoc :db-after db-after
+               :t t
+               :hash hash)
+        (update :flakes into flakes)
+        (update :block-bytes + bytes)
+        (update :fuel + fuel)
+        (update :remove-preds into remove-preds)
+        (cond-> type (update :cmd-types conj type)
+                txid (assoc-in [:txns txid] (util/without-nils ;; note the "block" transaction won't have a txid
+                                              (-> tx-result
+                                                  (assoc :id txid) ;; historically reported out :id and not :txid in tx result map
+                                                  (select-keys [:id :type :t :status :error :errors
+                                                                :tempids :auth :hash :authority
+                                                                :bytes :fuel :duration]))))))))
+
+
+(defn build-block-tx
+  "Generates the transaction for the block sealing, and returns the final block-map.
+  Note db-before is never updated during transactions, so it is the db before the block
+  was started."
+  [{:keys [db-before flakes t prev-hash block before-t txns instant] :as block-map} session]
+  (go-try
+    (let [private-key         (:tx-private-key (:conn session))
+          block-t             (dec t)
+          prevHash-flake      (flake/->Flake block-t const/$_block:prevHash prev-hash block-t true nil)
+          instant-flake       (flake/->Flake block-t const/$_block:instant instant block-t true nil)
+          number-flake        (flake/->Flake block-t const/$_block:number block block-t true nil)
+          tx-flakes           (mapv #(flake/->Flake block-t const/$_block:transactions % block-t true nil) (range block-t before-t))
+          block-flakes        (conj tx-flakes prevHash-flake instant-flake number-flake)
+          block-tx-hash       (tx-util/gen-tx-hash block-flakes)
+          block-tx-hash-flake (flake/->Flake block-t const/$_tx:hash block-tx-hash block-t true nil)
+          ;; We order each txn command according to the t
+          txn-hashes          (->> (vals txns)
+                                   (sort-by #(* -1 (:t %)))
+                                   (map :hash))
+          hash                (tx-util/generate-merkle-root (conj txn-hashes block-tx-hash))
+          sigs                [(crypto/sign-message hash private-key)]
+          hash-flake          (flake/->Flake block-t const/$_block:hash hash block-t true nil)
+          sigs-ref-flakes     (loop [[sig & sigs] sigs
+                                     acc []]
+                                (if-not sig
+                                  acc
+                                  (let [auth-sid (<? (dbproto/-subid db-before ["_auth/id" (crypto/account-id-from-message hash sig)]))
+                                        acc*     (if auth-sid
+                                                   (-> acc
+                                                       (conj (flake/->Flake block-t const/$_block:ledgers auth-sid block-t true nil))
+                                                       (conj (flake/->Flake block-t const/$_block:sigs sig block-t true nil)))
+                                                   acc)]
+                                    (recur sigs acc*))))
+          new-flakes*         (-> (into block-flakes sigs-ref-flakes)
+                                  (conj hash-flake)
+                                  (conj block-tx-hash-flake))
+          all-flakes          (into flakes new-flakes*)
+          latest-db           (<? (session/current-db session))
+          ;; if db was indexing and is now complete, add all flakes to newly indexed db... else just add new block flakes to latest db.
+          db-after            (cond
+                                (not= (:block latest-db) (:block db-before))
+                                (throw (ex-info "While performing transactions, latest db became newer. Cancelling."
+                                                {:status 500 :error :db/unexpected-error}))
+
+                                ;; nothing has changed, just add block flakes to latest db
+                                (= (get-in db-before [:stats :indexed]) (get-in latest-db [:stats :indexed]))
+                                (<? (dbproto/-with db-before block (sort flake/cmp-flakes-spot-novelty new-flakes*)))
+
+                                ;; database has been re-indexed while we were transacting. Use latest indexed
+                                ;; version and reapply all flakes from this block
+                                :else
+                                (do
+                                  (log/info "---> While transacting, database has been reindexed. Reapplying all block flakes to latest."
+                                            {:original-index (get-in db-before [:stats :indexed])
+                                             :latest-index   (get-in latest-db [:stats :indexed])})
+                                  (<? (dbproto/-with latest-db block all-flakes))))]
+      {:db-after db-after
+       :flakes   all-flakes
+       :hash     hash
+       :t        block-t
+       :fuel     0
+       :bytes    (- (get-in db-after [:stats :size]) (get-in db-before [:stats :size]))})))
+
+
+(defn retrieve-prev-hash
+  "Retrieves the latest block hash."
+  [db-current]
+  (go-try
+    (let [before-t        (:t db-current)
+          prev-hash-flake (first (<? (query-range/index-range db-current :spot = [before-t const/$_block:hash])))]
+      (when-not prev-hash-flake
+        (throw (ex-info (str "Unable to retrieve previous block hash. Unexpected error.")
+                        {:status 500
+                         :error  :db/unexpected-error})))
+      (.-o ^Flake prev-hash-flake))))
+
+
+(defn propose-block
+  "Proposes block to consensus network. Returns core async channel with success or failure."
+  [{:keys [group] :as conn} network dbid {:keys [flakes] :as block-map}]
+  (let [block-map' (-> block-map
+                       (dissoc :fuel :db-before :db-after :before-t :prev-hash :remove-preds)
+                       (assoc :flakes (into [] flakes)))]
+    (txproto/propose-new-block-async group network dbid block-map')))
+
+
+(defn- error-unexpected-tx
+  "Unexpected error processing a transaction error."
+  [e {:keys [group] :as conn} network {:keys [id] :as cmd-data}]
+  (if-let [message (ex-message e)]
+    (log/warn message)
+    (log/error e (format "Unexpected transaction error. Removing transaction with id: %s." id)))
+  ;; remove transaction in background - possible if no other work tx will get attempted again
+  (txproto/remove-command-from-queue group network id)
+  true)
+
+
+(defn- remove-all-txids
+  "Under a bad exception case, removes all txids part of the block so they
+  don't attempt to get processed again. It does this synchronously and will hold
+  the block transactor."
+  [conn network block-map]
+  (let [txids (keys (:txns block-map))]
+    (log/info (str "To prevent additional exceptions, removing all transactions that are part of the block: " txids))
+    (doseq [txid txids]
+      (let [res (async/<!! (txproto/remove-command-from-queue (:group conn) network txid))]
+        (when (util/exception? res)
+          (log/error res (str "Fatal error, after an error processing a block "
+                              "an unexpected error happened trying to remove the involved "
+                              "transactions from raft state: " txids))
+          (System/exit 1))))))
+
+
+(defn- catch-build-block-exception
+  "Unexpected error while building a new block around transaction(s)."
+  [conn network block-map block-result]
+  (if-not (util/exception? block-result)
+    block-result
+    (let [ex-msg (ex-message block-result)]
+      (if ex-msg
+        (log/warn ex-msg)
+        (log/error block-result
+                   (str "Unexpected error while building a new block around transactions: "
+                        (keys (:txns block-map)) ".")))
+      (remove-all-txids conn network block-map)
+      ;; explicitly returning nil will halt farther processing on block
+      nil)))
+
+
+(defn- error-propose-new-block
+  "Error handler for unexpected exception when proposing a new block."
+  [conn network block-result new-block-resp-ex]
+  (log/error new-block-resp-ex (str "Unexpected consensus error proposing new block: "
+                                    (.getMessage new-block-resp-ex)))
+  (remove-all-txids conn network block-result))
+
+
 (defn build-block
   "Builds a new block with supplied transaction(s)."
-  [session transactions]
+  [{:keys [conn network dbid] :as session} transactions]
   (go-try
-    (let [private-key   (:tx-private-key (:conn session))
-          db-current    (<? (session/current-db session))
-          _             (when (nil? db-current)
-                          ;; TODO - think about this error, if it is possible, and what to do with any pending transactions
-                          (log/warn "Unable to find a current db. Db transaction processor closing for db: %s/%s." (:network session) (:dbid session))
-                          (session/close session)
-                          (throw (ex-info (format "Unable to find a current db for: %s/%s." (:network session) (:dbid session))
-                                          {:status 400 :error :db/invalid-transaction})))
-          block         (inc (:block db-current))
-          block-instant (util/current-time-millis)
-          before-t      (:t db-current)
-          prev-hash     (some-> (query-range/index-range db-current :spot = [before-t const/$_block:hash])
-                                <?
-                                first
-                                .-o) ; get hash (object) from flake
-          _             (when-not prev-hash
-                          (throw (ex-info (str "Unable to retrieve previous block hash. Unexpected error.")
-                                          {:status 500
-                                           :error  :db/unexpected-error})))]
+    (let [db-current (<? (session/current-db session))
+          _          (when (nil? db-current)
+                       ;; TODO - think about this error, if it is possible, and what to do with any pending transactions
+                       (log/warn "Unable to find a current db. Db transaction processor closing for db: %s/%s." network dbid)
+                       (session/close session)
+                       (throw (ex-info (format "Unable to find a current db for: %s/%s." network dbid)
+                                       {:status 400 :error :db/invalid-transaction})))
+          prev-hash  (<? (retrieve-prev-hash db-current))]
       ;; perform each transaction in order
       (loop [[cmd-data & r] transactions
-             next-t           (dec before-t)
-             db-root          db-current
-             block-bytes      0
-             block-fuel       0
-             block-flakes     (flake/sorted-set-by flake/cmp-flakes-block)
-             cmd-types        #{}
-             txns             {}
-             remove-preds-acc #{}]
-        (let [start-time    (util/current-time-millis)
-              tx-result     (<? (tx-core/transact db-root cmd-data next-t block-instant))
-              {:keys [db-after bytes fuel flakes tempids auth authority status error errors
-                      hash remove-preds]} tx-result
-              block-bytes*  (+ block-bytes bytes)
-              block-fuel*   (+ block-fuel fuel)
-              block-flakes* (into block-flakes flakes)
-              cmd-type      (:type tx-result)
-              cmd-types*    (conj cmd-types cmd-type)
-              txns*         (assoc txns (:id cmd-data) (util/without-nils
-                                                         {:t         next-t ;; subject id
-                                                          :status    status
-                                                          :error     error
-                                                          :errors    errors
-                                                          :tempids   tempids
-                                                          :bytes     bytes
-                                                          :id        (:id cmd-data)
-                                                          :fuel      fuel
-                                                          :duration  (str (- (util/current-time-millis) start-time) "ms")
-                                                          :auth      auth
-                                                          :hash      hash
-                                                          :authority authority
-                                                          :type      cmd-type}))
-              remove-preds* (into remove-preds-acc remove-preds)]
+             block-map (->block-map db-current prev-hash)]
+        (let [block-map* (try
+                           (->> (tx-util/validate-command cmd-data)
+                                (tx-core/transact block-map)
+                                <?
+                                (merge-tx-into-block block-map))
+                           (catch Throwable e
+                             (error-unexpected-tx e conn network cmd-data)
+                             ;; return unalterted block-map
+                             block-map))]
           (if r
-            (recur r (dec next-t) db-after block-bytes* block-fuel* block-flakes* cmd-types* txns*
-                   remove-preds*)
-            (let [block-t             (dec next-t)
-                  prevHash-flake      (flake/->Flake block-t const/$_block:prevHash prev-hash block-t true nil)
-                  instant-flake       (flake/->Flake block-t const/$_block:instant block-instant block-t true nil)
-                  number-flake        (flake/->Flake block-t const/$_block:number block block-t true nil)
-                  tx-flakes           (mapv #(flake/->Flake block-t const/$_block:transactions % block-t true nil) (range block-t before-t))
-                  block-flakes        (conj tx-flakes prevHash-flake instant-flake number-flake)
-                  block-tx-hash       (tx-util/gen-tx-hash block-flakes)
-                  block-tx-hash-flake (flake/->Flake block-t const/$_tx:hash block-tx-hash block-t true nil)
-                  ;; We order each txn command according to the t
-                  txn-hashes          (->> (vals txns*)
-                                           (sort-by #(* -1 (:t %)))
-                                           (map :hash))
-                  hash                (tx-util/generate-merkle-root (conj txn-hashes block-tx-hash))
-                  sigs                [(crypto/sign-message hash private-key)]
-                  hash-flake          (flake/->Flake block-t const/$_block:hash hash block-t true nil)
-                  sigs-ref-flakes     (loop [[sig & sigs] sigs
-                                             acc []]
-                                        (if-not sig
-                                          acc
-                                          (let [auth-sid (<? (dbproto/-subid db-current ["_auth/id" (crypto/account-id-from-message hash sig)]))
-                                                acc*     (if auth-sid
-                                                           (-> acc
-                                                               (conj (flake/->Flake block-t const/$_block:ledgers auth-sid block-t true nil))
-                                                               (conj (flake/->Flake block-t const/$_block:sigs sig block-t true nil)))
-                                                           acc)]
-                                            (recur sigs acc*))))
-                  new-flakes*         (-> (into block-flakes sigs-ref-flakes)
-                                          (conj hash-flake)
-                                          (conj block-tx-hash-flake))
-                  all-flakes          (into block-flakes* new-flakes*)
-                  latest-db           (<? (session/current-db session))
-                  ;; if db was indexing and is now complete, add all flakes to newly indexed db... else just add new block flakes to latest db.
-                  db-after*           (cond
-                                        (not= (:block latest-db) (:block db-current))
-                                        (throw (ex-info "While performing transactions, latest db became newer. Cancelling."
-                                                        {:status 500 :error :db/unexpected-error}))
+            (recur r block-map*)
+            (if (:db-after block-map*)
+              (let [block-result   (some->> (async/<! (build-block-tx block-map* session))
+                                            (catch-build-block-exception conn network block-map*) ;; will return nil if exception
+                                            (merge-tx-into-block block-map*))
+                    new-block-resp (when block-result
+                                     (async/<! (propose-block conn network dbid block-result)))]
+                (cond
+                  (true? new-block-resp)
+                  (do
+                    (<? (indexing/index* session (select-keys block-map* [:remove-preds])))
+                    block-result)
 
-                                        ;; nothing has changed, just add block flakes to latest db
-                                        (= (get-in db-current [:stats :indexed]) (get-in latest-db [:stats :indexed]))
-                                        (<? (dbproto/-with db-after block (sort flake/cmp-flakes-spot-novelty new-flakes*)))
+                  (util/exception? new-block-resp)
+                  (error-propose-new-block conn network block-result new-block-resp)
 
-                                        ;; database has been re-indexed while we were transacting. Use latest indexed
-                                        ;; version and reapply all flakes from this block
-                                        :else
-                                        (do
-                                          (log/info "---> While transacting, database has been reindexed. Reapplying all block flakes to latest."
-                                                    {:original-index (get-in db-current [:stats :indexed]) :latest-index (get-in latest-db [:stats :indexed])})
-                                          (<? (dbproto/-with latest-db block all-flakes))))
-                  block-result        {:db-before   db-current
-                                       :db-after    db-after*
-                                       :cmd-types   cmd-types*
-                                       :block       block
-                                       :t           block-t
-                                       :hash        hash
-                                       :sigs        sigs
-                                       :instant     block-instant
-                                       :flakes      (into [] all-flakes)
-                                       :block-bytes (- (get-in db-after* [:stats :size]) (get-in db-current [:stats :size]))
-                                       :txns        txns*}
-                  ;; update db status for tx group
-                  new-block-resp      (<? (txproto/propose-new-block-async
-                                            (-> session :conn :group) (:network session)
-                                            (:dbid session) (dissoc block-result :db-before :db-after)))]
-              (if (true? new-block-resp)
-                (do
-                  (<? (indexing/index* session {:remove-preds remove-preds*}))
-                  block-result)
-                (do
-                  (log/warn "Proposed block was not accepted by the network because: "
-                            (pr-str new-block-resp)
-                            "Proposed block: "
-                            (dissoc block-result :db-before :db-after))
-                  false)))))))))
+                  :else
+                  (do
+                    (log/warn "Proposed block was not accepted by the network because: "
+                              (pr-str new-block-resp)
+                              "Proposed block: "
+                              (dissoc block-result :db-before :db-after))
+                    false)))
+              (do                                           ;; all transactions errored out
+                (log/info "Block processing resulted in no new blocks, all transaction attempts had issues.")
+                false))))))))

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -1,4 +1,4 @@
-(ns fluree.db.ledger.transact.json
+(ns fluree.db.ledger.transact.core
   (:require [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -404,12 +404,24 @@
   by updating the nested txis with their respective tempids. Will recursively check all nested txis for
   children."
   [txi tx-state]
-  (let [[updated-txi found-txis] (extract-children* txi tx-state)]
-    (if found-txis
-      ;; recur on children (nested transactions) for possibly additional children
-      (let [found-nested (mapcat #(extract-children % tx-state) found-txis)]
-        (conj found-nested updated-txi))
-      [updated-txi])))
+  (cond
+    (empty? txi)
+    (throw (ex-info (str "Empty or nil transaction item found in transaction.")
+                    {:status 400
+                     :error :db/invalid-transaction}))
+
+    (not (map? txi))
+    (throw (ex-info (str "All transaction items must be maps/objects, at least one is not.")
+                    {:status 400
+                     :error :db/invalid-transaction}))
+
+    :else
+    (let [[updated-txi found-txis] (extract-children* txi tx-state)]
+      (if found-txis
+        ;; recur on children (nested transactions) for possibly additional children
+        (let [found-nested (mapcat #(extract-children % tx-state) found-txis)]
+          (conj found-nested updated-txi))
+        [updated-txi]))))
 
 
 (defn ->tx-state

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -425,7 +425,7 @@
 
 
 (defn ->tx-state
-  [db t block-instant {:keys [auth auth-sid authority authority-sid tx-permissions txid cmd sig nonce type] :as tx-map}]
+  [db block-instant {:keys [auth auth-sid authority authority-sid tx-permissions txid cmd sig nonce type] :as tx-map}]
   (let [tx        (case (keyword (:type tx-map))            ;; command type is either :tx or :new-db
                     :tx (:tx tx-map)
                     :new-db (tx-util/create-new-db-tx tx-map))
@@ -440,7 +440,7 @@
      :auth             auth-sid                             ;; auth subject-id integer
      :authority-id     authority                            ;; authority id string as per _auth/id (or nil if no authority)
      :authority        authority-sid                        ;; authority subject-id integer (or nil if no authority)
-     :t                t
+     :t                (dec (:t db))
      :instant          block-instant
      :txid             txid
      :tx-type          type
@@ -628,24 +628,18 @@
 
 
 (defn transact
-  [db-root cmd-data t block-instant]
+  [{:keys [db-before instant]} tx-map]
   (async/go
     (try
-      (let [tx-map   (try (tx-util/validate-command (:command cmd-data))
-                          (catch Exception e
-                            (log/error e "Unexpected error parsing command: " (pr-str cmd-data))
-                            (throw (ex-info "Unexpected error parsing command."
-                                            {:status   500
-                                             :error    :db/command-parse-exception
-                                             :cmd-data cmd-data}
-                                            e))))
-            _        (when (not-empty (:deps tx-map))       ;; transaction has dependencies listed, verify they are satisfied
-                       (<? (tx-validate/tx-deps-check db-root tx-map)))
-            tx-map*  (<? (tx-auth/add-auth-ids-permissions db-root tx-map))
-            tx-state (->tx-state db-root t block-instant tx-map*)
-            result   (async/<! (build-transaction tx-state))]
-        (if (util/exception? result)
-          (<? (tx-error/handler result tx-state))
-          result))
+      (when (not-empty (:deps tx-map))                      ;; transaction has dependencies listed, verify they are satisfied
+        (<? (tx-validate/tx-deps-check db-before tx-map)))
+      (let [start-time (util/current-time-millis)
+            tx-map*    (<? (tx-auth/add-auth-ids-permissions db-before tx-map))
+            tx-state   (->tx-state db-before instant tx-map*)
+            result     (async/<! (build-transaction tx-state))
+            result* (if (util/exception? result)
+                         (<? (tx-error/handler result tx-state))
+                         result)]
+        (assoc result* :duration (str (- (util/current-time-millis) start-time) "ms")))
       (catch Exception e
-        (async/<! (tx-error/pre-processing-handler e db-root cmd-data t))))))
+        (async/<! (tx-error/pre-processing-handler e db-before tx-map))))))

--- a/src/fluree/db/ledger/transact/validation.clj
+++ b/src/fluree/db/ledger/transact/validation.clj
@@ -526,23 +526,21 @@
   is an error.
 
   Exceptions here should throw: catch by go-try."
-  [db tx-map]
-  (let [deps (:deps tx-map)]
-    (go-try
-      (if (empty? deps)
+  [db {:keys [deps] :as tx-map}]
+  (go-try
+    (let [res (->> deps
+                   (reduce-kv (fn [query-acc key dep]
+                                (-> query-acc
+                                    (update :selectOne conj (str "?error" key))
+                                    (update :where conj [(str "?tx" key) "_tx/id" dep])
+                                    (update :optional conj [(str "?tx" key) "_tx/error" (str "?error" key)])))
+                              {:selectOne [] :where [] :optional []})
+                   (fdb/query-async (go-try db))
+                   <?)]
+      (if (and (seq res) (every? nil? res))
         true
-        (let [res (->> (reduce-kv (fn [query-acc key dep]
-                                    (-> query-acc
-                                        (update :selectOne conj (str "?error" key))
-                                        (update :where conj [(str "?tx" key) "_tx/id" dep])
-                                        (update :optional conj [(str "?tx" key) "_tx/error" (str "?error" key)])))
-                                  {:selectOne [] :where [] :optional []} deps)
-                       (fdb/query-async (go-try db))
-                       <?)]
-          (if (and (seq res) (every? nil? res))
-            true
-            (throw (ex-info (str "One or more of the dependencies for this transaction failed: " deps)
-                            {:status 403 :error :db/invalid-auth}))))))))
+        (throw (ex-info (str "One or more of the dependencies for this transaction failed: " deps)
+                        {:status 400 :error :db/invalid-dependency}))))))
 
 
 ;; Runtime

--- a/src/fluree/db/ledger/txgroup/monitor.clj
+++ b/src/fluree/db/ledger/txgroup/monitor.clj
@@ -306,11 +306,11 @@
                                            (log/warn (format "Ledger skipping new transactions because our last processed 't' is %s, but the latest db we can retrieve is at %s" last-t (:t db))))))))
                                  (catch Exception e
                                    (log/error e "Error processing new block. Exiting tx monitor loop.")))]
-              (when new-block
-                ;; in case we still have a queue to process, kick again until finished
+              (when (not-empty queue)                       ;; in case we still have a queue to process, kick again until finished
                 (async/put! chan ::kick))
-
-              (recur (or (:t new-block) last-t)))))))))
+              (recur (if new-block
+                       (:t new-block)
+                       last-t)))))))))
 
 
 (defn db-queue

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -283,12 +283,12 @@ or this server is not responsible for this ledger, will return false. Else true 
   "Returns command queue as a list of maps.
    Queued commands are stored in state machine with key-seq of [:cmd-queue network txid].
     Map keys are:
-    1. txid
-    2. data    - map of actual tx data
+    1. id
+    2. command    - command data (map)
     3. size    - size of command in bytes
     4. network
     5. dbid
-    6.instant - instant we put this tx into our state machine"
+    6. instant - instant we put this tx into our state machine"
   ([group]
    (->> (get-in (-local-state group) [:cmd-queue])
         (vals)

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -304,7 +304,12 @@ or this server is not responsible for this ledger, will return false. Else true 
 (defn queue-command-async
   "Writes a new tx to the queue"
   [group network ledger-id command-id command]
-  (kv-assoc-in-async group [:cmd-queue network command-id] {:command command :size (count (:cmd command)) :id command-id :network network :dbid ledger-id :instant (System/currentTimeMillis)}))
+  (kv-assoc-in-async group [:cmd-queue network command-id] {:command command
+                                                            :size (count (:cmd command))
+                                                            :id command-id
+                                                            :network network
+                                                            :dbid ledger-id
+                                                            :instant (System/currentTimeMillis)}))
 
 
 ;; Block commands

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -319,6 +319,11 @@ or this server is not responsible for this ledger, will return false. Else true 
   (let [command [:new-block network ledger-id block-data (this-server group)]]
     (-new-entry-async group command)))
 
+(defn remove-command-from-queue
+  "Removes a command that is in the queue so it will no longer attempt to be processed."
+  [group network command-id]
+  (kv-dissoc-in-async group [:cmd-queue network command-id]))
+
 ;; TODO - this should use a CAS, to ensure DB does not currently exist.
 (defn register-genesis-block-async
   "Only for use by bootstrap or copy. Registers a new genesis block.

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -36,7 +36,7 @@
             [fluree.db.ledger.delete :as delete]
             [fluree.db.meta :as meta]
             [fluree.db.storage.core :as storage-core]
-            [fluree.db.ledger.transact.json :as tx-json])
+            [fluree.db.ledger.transact.core :as tx-core])
   (:import (java.io Closeable)
            (java.time Instant)
            (java.net BindException)
@@ -303,7 +303,7 @@
           db-with       (<? (dbproto/-forward-time-travel db flakes'))
           next-t        (- (:t db-with) 1)
           session       (session/session conn ledger)
-          res           (<? (tx-json/transact db-with {:command cmd-data} next-t block-instant))
+          res           (<? (tx-core/transact db-with {:command cmd-data} next-t block-instant))
           {:keys [flakes fuel status error]} res
           _             (session/close session)]
       [{:status status}
@@ -330,7 +330,7 @@
         (let [cmd-data      (fdb/tx->command ledger txn private-key)
               next-t        (dec (:t db))
               block-instant (Instant/now)
-              res           (<? (tx-json/transact db {:command cmd-data} next-t block-instant))
+              res           (<? (tx-core/transact db {:command cmd-data} next-t block-instant))
               {:keys [flakes fuel status error db-after]} res
               fuel-tot      (+ fuel-tot fuel)
               _             (when (not= status 200)

--- a/test/fluree/db/ledger/transact/core_test.clj
+++ b/test/fluree/db/ledger/transact/core_test.clj
@@ -2,9 +2,8 @@
   (:require [clojure.test :refer :all]
             [clojure.core.async :as async]
             [fluree.db.ledger.memorydb :as memorydb]
-            [fluree.db.ledger.transact.core :as tjson]
-            [fluree.db.api :as fdb]
-            [fluree.db.util.json :as json])
+            [fluree.db.ledger.transact.core :as tx-core]
+            [fluree.db.api :as fdb])
   (:import (java.time Instant)))
 
 ;; TODO - some specific tests that we should consider including beyond the Fluree docs/examples tests we currently run.

--- a/test/fluree/db/ledger/transact/core_test.clj
+++ b/test/fluree/db/ledger/transact/core_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [clojure.core.async :as async]
             [fluree.db.ledger.memorydb :as memorydb]
-            [fluree.db.ledger.transact.json :as tjson]
+            [fluree.db.ledger.transact.core :as tjson]
             [fluree.db.api :as fdb]
             [fluree.db.util.json :as json])
   (:import (java.time Instant)))


### PR DESCRIPTION
This refactors block building to be a bit more broken out. Along the way many more exception conditions are handled to keep the transactor loop running smoothly.

A new capability to remove a transaction from the queue in raft state is added, such that exceptions can not only report out but remove the offending transaction(s) and continue moving forward.

This addresses tickets FC-1239 and FC-1242
