### PR TITLE
FC-1216 Fix/tx unique swap

### DIFF
--- a/src/fluree/db/ledger/transact/validation.clj
+++ b/src/fluree/db/ledger/transact/validation.clj
@@ -120,7 +120,8 @@
   (let [f (fn [{:keys [flakes t]}]
             (let [check-flake (flake/flip-flake existing-flake t)
                   retracted?  (contains? flakes check-flake)]
-              (when-not retracted?
+              (if retracted?
+                true
                 (throw (ex-info (str "Unique predicate " (pred-info :name) " with value: "
                                      object " matched an existing subject.")
                                 {:status   400

--- a/src/fluree/db/ledger/transact/validation.clj
+++ b/src/fluree/db/ledger/transact/validation.clj
@@ -562,14 +562,14 @@
     (let [{:keys [queue]} @validate-fn]
       (when (not-empty queue)                               ;; if nothing in queue, return
         (let [tx-state* (assoc tx-state :flakes all-flakes)
-
               queue-ch  (async/chan parallelism)
               result-ch (async/chan parallelism)
               af        (fn [f res-chan]
                           (async/go
                             (let [fn-result (as-> (f tx-state*) res
                                                   (if (channel? res) (async/<! res) res))]
-                              (async/put! res-chan fn-result)
+                              (when-not (nil? fn-result)
+                                (async/put! res-chan fn-result))
                               (async/close! res-chan))))]
 
           ;; kicks off process to push queue onto queue-ch


### PR DESCRIPTION
This fix addresses error that could occur if swapping unique predicate IDs across two subjects in the same transaction as described by FC-1216.

Fix involves (a) adjusting validation function so it never returns nil, and returns true on success, and (b) adding a nil guard to put result on a channel - in case any other future functions accidentally return nil values.