### PR TITLE
FC-1096 Added information about pending transactions to nw-state

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -1,8 +1,7 @@
 (ns fluree.db.peer.http-api
   (:require [clojure.tools.logging :as log]
-            [clojure.walk :as walk]
             [clojure.string :as str]
-            [clojure.core.async :as async :refer [<!!]]
+            [clojure.core.async :as async]
             [org.httpkit.server :as http]
             [compojure.core :as compojure :refer [defroutes]]
             [compojure.route :as route]
@@ -27,6 +26,7 @@
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
             [fluree.db.serde.protocol :as serdeproto]
             [fluree.db.permissions-validate :as permissions-validate]
+            [fluree.db.peer.server-health :as server-health]
             [fluree.db.peer.password-auth :as pw-auth]
             [fluree.db.ledger.reindex :as reindex]
             [fluree.db.ledger.mutable :as mutable]
@@ -604,71 +604,6 @@
    :body    (meta/version)})
 
 
-(defn- remove-deep
-  [key-set data]
-  (walk/prewalk (fn [node] (if (map? node)
-                             (apply dissoc node key-set)
-                             node))
-                data))
-
-
-(defn nw-state-handler
-  [system _]
-  (let [open-api? (open-api? system)
-        raft      (-> system :group :state-atom deref (dissoc :private-key))
-        {:keys [cmd-queue new-db-queue networks leases]} raft
-        instant   (System/currentTimeMillis)
-        cmd-q     (loop [[cq & r] cmd-queue
-                         acc []]
-                    (if cq
-                      (let [[k v] cq
-                            acc* (into acc [{(keyword k) (count v)}])]
-                        (recur r acc*))
-                      acc))
-        new-db-q  (loop [[nq & r] new-db-queue
-                         acc []]
-                    (if nq
-                      (let [[k v] nq
-                            acc* (into acc [{(keyword k) (count v)}])]
-                        (recur r acc*))
-                      acc))
-        nw-data   (->> networks (remove-deep [:private-key]) vector)
-        svr-state (when-let [servers (into [] (:servers leases))]
-                    (loop [[server & r] servers
-                           acc []]
-                      (if-let [item (second server)]
-                        (recur r (into acc [{:id      (:id item)
-                                             :active? (> (:expire item) instant)}]))
-                        acc)))
-        raft'     (-> raft
-                      (assoc :cmd-queue cmd-q
-                             :new-db-queue new-db-q
-                             :networks nw-data))
-        state     (-> (txproto/-state (:group system))
-                      (select-keys [:snapshot-term
-                                    :latest-index
-                                    :snapshot-index
-                                    :other-servers
-                                    :index
-                                    :snapshot-pending
-                                    :term
-                                    :leader
-                                    :timeout-at
-                                    :this-server
-                                    :status
-                                    :id
-                                    :commit
-                                    :servers
-                                    :voted-for
-                                    :timeout-ms])
-                      (assoc :open-api open-api?)
-                      (assoc :raft raft')
-                      (assoc :svr-state svr-state))]
-    {:status  200
-     :headers {"Content-Type" "application/json; charset=utf-8"}
-     :body    (json/stringify-UTF8 state)}))
-
-
 (defn add-server
   [system {:keys [body]}]
   (let [{:keys [server]} (decode-body body :json)
@@ -685,17 +620,6 @@
     {:status  200
      :headers {"Content-Type" "application/json; charset=utf-8"}
      :body    (json/stringify-UTF8 remove-server)}))
-
-
-(defn health-handler
-  [system _]
-  (let [state (-> (txproto/-state (:group system))
-                  :status)]
-    {:status  200
-     :headers {"Content-Type" "application/json; charset=utf-8"}
-     :body    (json/stringify-UTF8 {:ready       true
-                                    :status      state
-                                    :utilization 0.5})}))
 
 
 (defn keys-handler
@@ -901,8 +825,8 @@
     (compojure/GET "/fdb/storage/:network/:db/:type" request (storage-handler system request))
     (compojure/GET "/fdb/storage/:network/:db/:type/:key" request (storage-handler system request))
     (compojure/GET "/fdb/ws" request (websocket/handler system request))
-    (compojure/ANY "/fdb/health" request (health-handler system request))
-    (compojure/ANY "/fdb/nw-state" request (nw-state-handler system request))
+    (compojure/ANY "/fdb/health" request (server-health/health-handler system request))
+    (compojure/ANY "/fdb/nw-state" request (server-health/nw-state-handler system request))
     (compojure/GET "/fdb/version" request (version-handler system request))
     (compojure/POST "/fdb/add-server" request (add-server system request))
     (compojure/POST "/fdb/remove-server" request (remove-server system request))

--- a/src/fluree/db/peer/server_health.clj
+++ b/src/fluree/db/peer/server_health.clj
@@ -1,0 +1,192 @@
+(ns fluree.db.peer.server-health
+  (:require [clojure.core.async :as async]
+            [clojure.walk :as walk]
+            [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
+            [fluree.db.util.json :as json]))
+
+(def ^:const default-nwstate-timeout-ms 60000)              ;; TODO - What should be the default setting?
+
+;200 OK. The client request has succeeded
+(def ^:const http-ok 200)
+
+; 408 Request Timeout. The server did not complete the request before the client expiration timeout.
+(def ^:const http-timeout 408)
+
+;500 Internal Server Error. An unknown error has occurred.
+(def ^:const http-internal-server-error 500)
+
+
+(defn remove-deep
+  "Walks a nested map, removing key(s)/value(s) based on keys provided.
+
+  key-set - identifies keys (with values) to be removed
+  data    - a nested map"
+  [key-set data]
+  (walk/prewalk (fn [node] (if (map? node)
+                             (apply dissoc node key-set)
+                             node))
+                data))
+
+(defn extract-state-from-leases
+  "Extracts current state of server network based on the current server's view.
+
+  Inputs:
+  group - map of server leases from the consensus (e.g., raft) state
+
+  Returns: a vector of maps containing
+     :id      - server identifier (e.g., myserver)
+     :active? - indicator whether or not the servers are in active communication
+
+  Should never return nil; but...
+  "
+  [leases instant]
+  (when-let [servers (into [] (:servers leases))]
+    (loop [[server & r] servers
+           acc []]
+      (if-let [item (second server)]
+        (recur r (into acc [{:id      (:id item)
+                             :active? (>= (:expire item) instant)}]))
+        acc))))
+
+(defn parse-command-queue
+  "Retrieves current backlog from consensus state based on the current server's view.
+
+  Inputs:
+  cmd-queue - a map of outstanding transactions/commands from the consensus state
+
+  returns: a vector of maps, each map with
+     * the network as a keyword (e.g., given a ledger test/one; the id becomes :test)
+     * the count of pending transactions as the value of the keyword
+     * the keyword
+     * the instant of oldest transaction"
+  [cmd-queue]
+  (loop [[cq & r] cmd-queue
+         acc []]
+    (if cq
+      (let [[k v] cq
+            acc* (into acc [{(keyword k) (count v)
+                             :txn-count  (count v)
+                             :txn-oldest-instant (some->> v vals (map :instant) (apply min))
+                             }])]
+        (recur r acc*))
+      acc)))
+
+(defn parse-new-db-queue
+  "Retrieves current backlog from consensus state based on the current server's view.
+
+  Inputs:
+  new-db-queue - a map of outstanding 'new ledger' requests from the consensus state
+
+  returns: a vector of maps, each map with
+     * the network as a keyword (e.g., given a new ledger test/one; the id becomes :test)
+     * the count of pending new ledger requests as the value of the keyword"
+  [new-db-queue]
+  (loop [[nq & r] new-db-queue
+         acc []]
+    (if nq
+      (let [[k v] nq
+            acc* (into acc [{(keyword k) (count v)}])]
+        (recur r acc*))
+      acc)))
+
+(defn get-consensus-state
+  "Returns a nested map documenting the current state of the txproto group
+
+  Expects system as input, should contain the raft state"
+  [{:keys [group]}]
+  (let [instant    (System/currentTimeMillis)
+        raft       (-> group :state-atom deref (dissoc :private-key))
+        {:keys [cmd-queue new-db-queue networks leases]} raft
+        cmd-queue  (parse-command-queue cmd-queue)
+        oldest-txn (some->> cmd-queue
+                            (mapv (fn [m] (:txn-oldest-instant m)))
+                            (remove nil?)
+                            seq
+                            (apply min))
+        svr-state  (when leases
+                     (extract-state-from-leases leases instant))
+        raft'      (-> raft
+                       (assoc :cmd-queue    cmd-queue
+                              :new-db-queue (parse-new-db-queue new-db-queue)
+                              :networks     (some->> networks (remove-deep [:private-key]) vector)))]
+    (-> (txproto/-state group)
+        (select-keys [:snapshot-term
+                      :latest-index
+                      :snapshot-index
+                      :other-servers
+                      :index
+                      :snapshot-pending
+                      :term
+                      :leader
+                      :timeout-at
+                      :this-server
+                      :status
+                      :id
+                      :commit
+                      :servers
+                      :voted-for
+                      :timeout-ms])
+        (assoc :open-api (:open-api group))
+        (assoc :raft raft')
+        (assoc :svr-state svr-state)
+        (assoc :oldest-pending-txn-instant oldest-txn))))
+
+(defn get-request-timeout
+  "Retrieves the request-timeout from headers and returns the integer value.
+
+  If the request-timeout header is not defined or the provided value cannot be coerced to an integer,
+  the default-value is assigned."
+  [{:keys [headers]} default-value]
+  (if-let [t (:request-timeout headers)]
+    (if (integer? t)
+      t
+      (try (Integer/parseInt t)
+           (catch Exception _ default-value)))
+    default-value))
+
+(defn health-handler
+  [{:keys [config group]} _]
+  (let [state (cond
+                group
+                (-> group txproto/-state :status)
+
+                (:transactor? config)
+                "ledger"
+
+                :else
+                "query")]
+    {:status  http-ok
+     :headers {"Content-Type" "application/json; charset=utf-8"}
+     :body    (json/stringify-UTF8 {:ready       true
+                                    :status      state
+                                    :utilization 0.5})}))
+
+(defn nw-state-handler
+  [{:keys [config group] :as system} request]
+  (let [timeout (get-request-timeout request default-nwstate-timeout-ms)
+        attempt (async/go
+                  (try
+                    (let [body (cond
+                                 group
+                                 (get-consensus-state system)
+
+                                 (:transactor? config)
+                                 {:status "ledger"}
+
+                                 :else
+                                 {:status "query"})]
+                      {:status  http-ok
+                       :headers {"Content-Type" "application/json; charset=utf-8"}
+                       :body    (json/stringify-UTF8 body)})
+                    (catch Exception e
+                      {:status  (or (-> e ex-data :status) http-internal-server-error)
+                       :headers {"Content-Type" "application/json; charset=utf-8"}
+                       :body    (json/stringify-UTF8 e)})))
+        [resp ch] (async/alts!! [attempt (async/timeout timeout)])]
+    (if (= ch attempt)
+      resp
+      {:status  http-timeout
+       :headers {"Content-Type" "text/plain"}
+       :body    (->> timeout
+                     (format "Client Timeout. Request did not complete in %d ms" )
+                     json/stringify-UTF8)})))

--- a/test/fluree/db/ledger/api/downloaded.clj
+++ b/test/fluree/db/ledger/api/downloaded.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.api.downloaded
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.util.log :as log]
             [clojure.tools.reader.edn :as edn]
             [clojure.java.io :as io]

--- a/test/fluree/db/ledger/docs/examples/cryptocurrency.clj
+++ b/test/fluree/db/ledger/docs/examples/cryptocurrency.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.examples.cryptocurrency
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/examples/supply_chain.clj
+++ b/test/fluree/db/ledger/docs/examples/supply_chain.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.examples.supply-chain
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/examples/voting.clj
+++ b/test/fluree/db/ledger/docs/examples/voting.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.examples.voting
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/getting_started/basic_schema.clj
+++ b/test/fluree/db/ledger/docs/getting_started/basic_schema.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.getting-started.basic-schema
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]
             [clojure.java.io :as io]

--- a/test/fluree/db/ledger/docs/identity/auth.clj
+++ b/test/fluree/db/ledger/docs/identity/auth.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.identity.auth
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/identity/signatures.clj
+++ b/test/fluree/db/ledger/docs/identity/signatures.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.identity.signatures
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.ledger.api.downloaded :as downloaded]
             [fluree.db.api :as fdb]

--- a/test/fluree/db/ledger/docs/query/advanced_query.clj
+++ b/test/fluree/db/ledger/docs/query/advanced_query.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.query.advanced-query
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/query/analytical_query.clj
+++ b/test/fluree/db/ledger/docs/query/analytical_query.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.query.analytical-query
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/query/basic_query.clj
+++ b/test/fluree/db/ledger/docs/query/basic_query.clj
@@ -1,7 +1,7 @@
 (ns fluree.db.ledger.docs.query.basic-query
   (:require [clojure.test :refer :all]
             [clojure.stacktrace :refer [root-cause]]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [fluree.db.util.core :as utils]

--- a/test/fluree/db/ledger/docs/query/block_query.clj
+++ b/test/fluree/db/ledger/docs/query/block_query.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.query.block-query
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/query/graphql.clj
+++ b/test/fluree/db/ledger/docs/query/graphql.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.query.graphql
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]))

--- a/test/fluree/db/ledger/docs/query/history_query.clj
+++ b/test/fluree/db/ledger/docs/query/history_query.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.query.history-query
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/query/sparql.clj
+++ b/test/fluree/db/ledger/docs/query/sparql.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.query.sparql
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]))

--- a/test/fluree/db/ledger/docs/query/sql_query.clj
+++ b/test/fluree/db/ledger/docs/query/sql_query.clj
@@ -1,7 +1,7 @@
 (ns fluree.db.ledger.docs.query.sql-query
   (:require [clojure.test :refer :all]
             [clojure.stacktrace :refer [root-cause]]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [fluree.db.util.core :as utils]

--- a/test/fluree/db/ledger/docs/schema/collections.clj
+++ b/test/fluree/db/ledger/docs/schema/collections.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.schema.collections
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/schema/predicates.clj
+++ b/test/fluree/db/ledger/docs/schema/predicates.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.schema.predicates
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]

--- a/test/fluree/db/ledger/docs/smart_functions/collection_spec.clj
+++ b/test/fluree/db/ledger/docs/smart_functions/collection_spec.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.smart-functions.collection-spec
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [clojure.core.async :as async]
             [fluree.db.api :as fdb]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]))

--- a/test/fluree/db/ledger/docs/smart_functions/in_transactions.clj
+++ b/test/fluree/db/ledger/docs/smart_functions/in_transactions.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.smart-functions.in-transactions
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]))

--- a/test/fluree/db/ledger/docs/smart_functions/intro.clj
+++ b/test/fluree/db/ledger/docs/smart_functions/intro.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.smart-functions.intro
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [clojure.core.async :as async]
             [fluree.db.api :as fdb]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]))

--- a/test/fluree/db/ledger/docs/smart_functions/predicate_spec.clj
+++ b/test/fluree/db/ledger/docs/smart_functions/predicate_spec.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.docs.smart-functions.predicate-spec
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [clojure.core.async :as async]
             [fluree.db.api :as fdb]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]))

--- a/test/fluree/db/ledger/docs/smart_functions/rule_example.clj
+++ b/test/fluree/db/ledger/docs/smart_functions/rule_example.clj
@@ -5,7 +5,7 @@
             [clojure.core.async :as async]
             [fluree.db.api :as fdb]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.query.http-signatures :as http-signatures]
             [org.httpkit.client :as http]
             [byte-streams :as bs]

--- a/test/fluree/db/ledger/docs/transact/transactions.clj
+++ b/test/fluree/db/ledger/docs/transact/transactions.clj
@@ -1,7 +1,7 @@
 (ns fluree.db.ledger.docs.transact.transactions
   (:require [clojure.test :refer :all]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.api :as fdb]
             [clojure.core.async :as async]
             [clojure.string :as str])

--- a/test/fluree/db/ledger/general/todo_permissions.clj
+++ b/test/fluree/db/ledger/general/todo_permissions.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [clojure.core.async :as async]
             [clojure.string :as str]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]))
 

--- a/test/fluree/db/ledger_test.clj
+++ b/test/fluree/db/ledger_test.clj
@@ -1,6 +1,6 @@
-(ns fluree.db.ledger.ledger-test
+(ns fluree.db.ledger-test
   (:require [clojure.test :refer :all]
-            [fluree.db.ledger.test-helpers :as test]
+            [fluree.db.test-helpers :as test]
 
             [fluree.db.ledger.api.downloaded :as api]
 
@@ -32,7 +32,8 @@
             [fluree.db.ledger.docs.examples.cryptocurrency :as cryptocurrency]
             [fluree.db.ledger.docs.examples.supply-chain :as supply-chain]
             [fluree.db.ledger.docs.examples.voting :as voting]
-            [fluree.db.ledger.general.todo-permissions :as todo-perm]))
+            [fluree.db.ledger.general.todo-permissions :as todo-perm]
+            [fluree.db.peer.server-health-tests :as sh-test]))
 
 ;; TODO - tests fail - commented out for convenience:
 ;; API - (test-gen-flakes-query-transact-with)
@@ -106,7 +107,12 @@
 
              ;; 9- General
              (test/print-banner "General Tests")
-             (todo-perm/todo-auth-tests))))))
+             (todo-perm/todo-auth-tests)
+
+             ;; 10- Server health
+             (test/print-banner "Server Health")
+             (sh-test/server-health-tests)
+             )))))
 
 (comment
 

--- a/test/fluree/db/peer/server_health_tests.clj
+++ b/test/fluree/db/peer/server_health_tests.clj
@@ -1,0 +1,118 @@
+(ns fluree.db.peer.server-health-tests
+  (:require [clojure.test :refer :all]
+            [byte-streams :as bs]
+            [fluree.db.peer.server-health :as srv-health]
+            [fluree.db.test-helpers :as test]
+            [fluree.db.util.json :as json]
+            [clojure.string :as str]))
+
+(def ^:const instant-now (System/currentTimeMillis))
+(def ^:const instant-oldest-txn (- instant-now 5000))
+(def ^:const state-leases {:servers {:server-id {:id :DEF :expire (+ instant-now 300000)}}})
+(def ^:const state-cmd-queue {"test" {"txid" {:data    {:cmd "" :sig ""}
+                                              :size    400
+                                              :txid    "txid"
+                                              :network "network"
+                                              :dbid    "dbid"
+                                              :instant instant-oldest-txn}}
+                              "fluree" {"txid" {:data    {:cmd "" :sig ""}
+                                                :size    2400
+                                                :txid    "txid"
+                                                :network "network"
+                                                :dbid    "dbid"
+                                                :instant instant-now}}})
+(def ^:const state-new-db-queue {"test" {"id" {:network "test"
+                                               :dbid    "new-ledger"
+                                               :command {:cmd "command-json" :sig "sig"}}}})
+
+(deftest server-health-tests
+  (testing "remove-deep"
+    (let [original {:level-1 {:level-2 {:private-key "abcd" :other "1234"}
+                              :private-key "4567"}
+                    :private-key "7890"}
+          expected {:level-1 {:level-2 {:other "1234"}}}]
+      (is (= expected (srv-health/remove-deep [:private-key] original)))))
+  (testing "extract-state-from-leases"
+    (let [res (srv-health/extract-state-from-leases state-leases instant-now)]
+      (is (vector? res))
+      (is (-> res first (test/contains-many? :id :active?)))))
+  (testing "parse-command-queue"
+    (let [res (srv-health/parse-command-queue state-cmd-queue)]
+      (is (vector? res))
+      (is (-> res
+              first
+              (test/contains-many? :txn-count :txn-oldest-instant)))))
+  (testing "parse-new-db-queue"
+    (let [res (srv-health/parse-new-db-queue state-new-db-queue)]
+      (is (vector? res))
+      (is (= 1 (count res)))))
+  (testing "get-consensus-state"
+    (let [state   (-> test/system
+                      :group
+                      :state-atom
+                      deref
+                      (assoc :leases state-leases)
+                      (assoc :cmd-queue state-cmd-queue)
+                      (assoc :new-db-queue state-new-db-queue)
+                      atom)
+          system* (assoc-in test/system [:group :state-atom] state)
+          res     (srv-health/get-consensus-state system*)]
+      (is (map? res))
+      (is (test/contains-many? res :open-api :raft :svr-state :oldest-pending-txn-instant))
+      (is (= instant-oldest-txn (:oldest-pending-txn-instant res)))))
+  (testing "get-request-timeout"
+    (testing "integer"
+      (let [res (srv-health/get-request-timeout {:headers {:request-timeout 5}} nil)]
+        (is (= 5 res))))
+    (testing "default value"
+      (let [res (srv-health/get-request-timeout {:headers {}} 25)]
+        (is (= 25 res))))
+    (testing "string"
+      (let [res (srv-health/get-request-timeout {:headers {:request-timeout "5"}} nil)]
+        (is (= 5 res)))))
+  (testing "health handler"
+    (testing "standard"
+      (let [res  (srv-health/health-handler test/system nil)
+            body (-> res :body bs/to-string json/parse)]
+        (is (= srv-health/http-ok (:status res)))
+        (is (map? body))
+        (is (test/contains-many? body :ready :status :utilization))))
+    (testing "missing group; is transactor?"
+      (let [res  (srv-health/health-handler {:config {:transactor? true}} nil)
+            body (-> res :body bs/to-string json/parse)]
+        (is (= srv-health/http-ok (:status res)))
+        (is (= "ledger" (:status body)))))
+    (testing "query peer"
+      (let [res  (srv-health/health-handler {:config {:transactor? false}} nil)
+            body (-> res :body bs/to-string json/parse)]
+        (is (= srv-health/http-ok (:status res)))
+        (is (= "query" (:status body))))))
+  (testing "network state handler"
+    (testing "consensus - no queue"
+      (let [res  (srv-health/nw-state-handler test/system nil)
+            body (-> res :body bs/to-string json/parse)]
+        (is (= srv-health/http-ok (:status res)))
+        (is (map? body))
+        (is (test/contains-many? body :open-api :raft :svr-state :oldest-pending-txn-instant))))
+    (testing "consensus - with queue"
+      (let [state   (-> test/system
+                        :group
+                        :state-atom
+                        deref
+                        (assoc :leases state-leases)
+                        (assoc :cmd-queue state-cmd-queue)
+                        (assoc :new-db-queue state-new-db-queue)
+                        atom)
+            system* (assoc-in test/system [:group :state-atom] state)
+            res     (srv-health/nw-state-handler system* nil)
+            body    (-> res :body bs/to-string json/parse)]
+        (is (= srv-health/http-ok (:status res)))
+        (is (map? body))
+        (is (test/contains-many? body :open-api :raft :svr-state :oldest-pending-txn-instant))
+        (is (= instant-oldest-txn (:oldest-pending-txn-instant body)))))
+    (testing "timeout"
+      (let [res  (srv-health/nw-state-handler test/system {:headers {:request-timeout 0}})
+            body (-> res :body bs/to-string json/parse)]
+        (is (= srv-health/http-timeout (:status res)))
+        (is (string? body))
+        (is (str/starts-with? body "Client Timeout."))))))

--- a/test/fluree/db/test_helpers.clj
+++ b/test/fluree/db/test_helpers.clj
@@ -1,4 +1,4 @@
-(ns fluree.db.ledger.test-helpers
+(ns fluree.db.test-helpers
   (:require [clojure.test :refer :all]
             [clojure.core.async :as async]
             [fluree.db.server :as server]
@@ -15,12 +15,12 @@
 (def port (delay (get-free-port)))
 (def alt-port (delay (get-free-port)))
 (def config (delay (setting/build-env
-                     {:fdb-mode              "dev"
-                      :fdb-group-servers     "DEF@localhost:11001"
-                      :fdb-group-this-server "DEF"
-                      :fdb-storage-type      "memory"
-                      :fdb-api-port          @port
-                      :fdb-consensus-type    "in-memory"})))
+                     {:fdb-mode                "dev"
+                      :fdb-group-servers       "DEF@localhost:11001"
+                      :fdb-group-this-server   "DEF"
+                      :fdb-storage-type        "memory"
+                      :fdb-api-port            @port
+                      :fdb-consensus-type      "in-memory"})))
 
 (def system nil)
 


### PR DESCRIPTION
* Added pending transaction information to nw-state endpoint
* Moved nw-state-handler and health-handler into a new namespace, server-health.  If you can think of a better name.
* Added unit tests for nw-state-handler and health-handler - named server-health-tests so it is executed only by the ledger-test entry point (for now).
* seemed odd that the ledger-test and test-helper namespaces were not in the fluree.db.peer tree; so, I moved "ledger" from their namespace