### PR TITLE
The new -X / :exec-fn feature eliminates the need for the :runner alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ target/fluree-ledger.jar: resources/adminUI $(SOURCES) $(RESOURCES)
 jar: target/fluree-ledger.jar
 
 test:
-	clojure -X:test:runner
+	clojure -X:test
 
 eastwood:
 	clojure -M:eastwood

--- a/deps.edn
+++ b/deps.edn
@@ -42,10 +42,7 @@
    :extra-deps  {org.clojure/tools.namespace {:mvn/version "1.1.0"}}}
 
   :test
-  {:extra-paths ["test"]}
-
-  :runner
-  {:extra-paths ["test-resources"]
+  {:extra-paths ["test" "test-resources"]
    :extra-deps  {com.cognitect/test-runner
                  {:git/url "https://github.com/cognitect-labs/test-runner.git"
                   :sha "dd6da11611eeb87f08780a30ac8ea6012d4c05ce"}}


### PR DESCRIPTION
You can now just do `clojure -X:test` (which is what `make test` will now invoke in this branch) to run the tests at the CLI or pull in the `:test` alias in your REPL and run them at will (or not). But they won't auto-execute as a side effect in the latter case. 🎉 