### PR TITLE
FC-1260 - ledger-stats http api call closes session, disrupting runni…

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -373,11 +373,9 @@
   [_ system _ _ ledger _]
   (go-try
     (let [conn    (:conn system)
-          session (session/session conn ledger)
           db-info (<? (fdb/ledger-info-async conn ledger))
           db-stat (-> (<? (session/db conn ledger {:connect? false}))
-                      (get-in [:stats]))
-          _       (session/close session)]
+                      (get-in [:stats]))]
       [{:status 200} {:status 200 :data (merge db-info db-stat)}])))
 
 


### PR DESCRIPTION
When a transaction is processing, session/close will cause an issue. For some reason, ledger-stats http api call always closed the session causing this issue.