### PR TITLE
Add test dir to dev alias

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,7 +38,7 @@
   :mvn/version "1.0.0-beta15"
 
   :dev
-  {:extra-paths ["dev"]
+  {:extra-paths ["dev", "test"]
    :extra-deps  {org.clojure/tools.namespace {:mvn/version "1.1.0"}}}
 
   :test


### PR DESCRIPTION
This allows you to run tests (e.g. from a REPL) with just the dev alias
loaded, and doesn't bring in test-resources in case you want to see the
log output. If you don't, you can bring in the test alias too and
logging will be disabled.