### PR TITLE
FC-1266 Fix/index hardening

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:deps {org.clojure/clojure               {:mvn/version "1.10.3"}
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.1"}
-        com.fluree/db                     {:mvn/version "1.0.0-rc29"}
+        com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
+                                           :sha "2b38fdfa50a9f3c0224d82f49ca86e96ac5a9a10"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.6"}
 
@@ -38,7 +39,7 @@
   :mvn/version "1.0.0-beta15"
 
   :dev
-  {:extra-paths ["dev"]
+  {:extra-paths ["dev" "test"]
    :extra-deps  {org.clojure/tools.namespace {:mvn/version "1.1.0"}}}
 
   :test

--- a/src/fluree/db/ledger/txgroup/monitor.clj
+++ b/src/fluree/db/ledger/txgroup/monitor.clj
@@ -271,61 +271,62 @@
 ;; TODO - need way for leader to reject new block if we changed who is responsible for a network in-between, and detect + close here
 (defn db-queue-loop
   "Runs a continuous loop for a db to process new blocks"
-  [conn chan network dbid]
+  [conn chan network dbid queue-id]
   (let [group       (:group conn)
         this-server (txproto/this-server group)]
-    (async/go-loop [last-t nil]
+    (async/go-loop [block-map nil]
       (let [kick (async/<! chan)]
         (when-not (nil? kick)
           (if-not (network-assigned-to? group this-server network)
             (do
               (log/info (str "Network " network " is no longer assigned to this server. Stopping to process transactions."))
               (close-db-queue network dbid))
-            (let [queue     (txproto/command-queue group network dbid)
-                  new-block (try (when (not-empty queue)
-                                   (let [session    (session/session conn [network dbid])
-                                         db         (<? (session/current-db session))
-                                         at-last-t? (or (nil? last-t)
-                                                        (= last-t (:t db)))]
-                                     (if at-last-t?
-                                       (let [cmds (select-block-commands db queue)]
-                                         (when-not (empty? cmds)
-                                           (->> cmds
-                                                (transact/build-block session)
-                                                <?)))
-                                       ;; db isn't up to date, shouldn't happen but before abandoning, dump and reload db to see if we can get current
-                                       (let [_           (session/clear-db! session)
-                                             db*         (<? (session/current-db session))
-                                             at-last-t?* (= last-t (:t db*))]
-                                         (if at-last-t?*
-                                           (do
-                                             (log/info (format "Ledger %s/%s is not automatically updating internally, session may be lost." network dbid))
-                                             (let [cmds (select-block-commands db queue)]
-                                               (when-not (empty? cmds)
-                                                 (->> cmds
-                                                      (transact/build-block session)
-                                                      <?))))
-                                           (log/warn (format "Ledger skipping new transactions because our last processed 't' is %s, but the latest db we can retrieve is at %s" last-t (:t db))))))))
-                                 (catch Exception e
-                                   (log/error e "Error processing new block. Exiting tx monitor loop.")))]
+            (let [queue      (txproto/command-queue group network dbid)
+                  block-map* (try
+                               (if (seq queue)
+                                 (let [session    (session/session conn [network dbid])
+                                       db         (or (:db-after block-map)
+                                                      (<? (session/current-db session)))
+                                       at-last-t? (or (nil? block-map)
+                                                      (= (:t block-map) (:t db)))]
+                                   (if at-last-t?
+                                     (let [cmds (select-block-commands db queue)]
+                                       (when-not (empty? cmds)
+                                         (->> cmds
+                                              (transact/build-block session db)
+                                              <?)))
+                                     ;; db isn't up to date, shouldn't happen but before abandoning, dump and reload db to see if we can get current
+                                     (let [_           (session/clear-db! session)
+                                           db*         (<? (session/current-db session))
+                                           at-last-t?* (= (:t block-map) (:t db*))]
+                                       (if at-last-t?*
+                                         (do
+                                           (log/info (format "Ledger %s/%s is not automatically updating internally, session may be lost." network dbid))
+                                           (let [cmds (select-block-commands db* queue)]
+                                             (when-not (empty? cmds)
+                                               (->> cmds
+                                                    (transact/build-block session db*)
+                                                    <?))))
+                                         (log/warn (format "Ledger skipping new transactions because our last processed 't' is %s, but the latest db we can retrieve is at %s" (:t block-map) (:t db)))))))
+                                 block-map)
+                               (catch Exception e
+                                 (log/error e "Error processing new block. Exiting tx monitor loop.")))]
               (when (not-empty queue)                       ;; in case we still have a queue to process, kick again until finished
                 (async/put! chan ::kick))
-              (recur (if new-block
-                       (:t new-block)
-                       last-t)))))))))
+              (recur block-map*))))))))
 
 
 (defn db-queue
   [conn network dbid]
   (or (get-in @db-queues-atom [network dbid])
-      (do
-        (swap! db-queues-atom (fn [x]
-                                (if (get-in x [network dbid])
-                                  x
+      (let [queue-id (str network "/" dbid ":" (rand-int 100000))]
+        (swap! db-queues-atom (fn [queues]
+                                (if (get-in queues [network dbid])
+                                  queues                    ;; race condition - queue was just created so don't create new one
                                   (let [chan (async/chan (async/dropping-buffer 1))]
                                     ;; kick off loop
-                                    (db-queue-loop conn chan network dbid)
-                                    (assoc-in x [network dbid] chan)))))
+                                    (db-queue-loop conn chan network dbid queue-id)
+                                    (assoc-in queues [network dbid] chan)))))
         (get-in @db-queues-atom [network dbid]))))
 
 

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -264,7 +264,7 @@
 
 
 (defmethod action-handler :command
-  [_ system param _ ledger timeout]
+  [_ system param _ ledger {:keys [timeout] :as opts}]
   (go-try
     (let [_      (when-not (and (map? param) (:cmd param))
                    (throw (ex-info (str "Api endpoint for 'command' must contain a map/object with cmd keys.")
@@ -493,7 +493,8 @@
                           (try (Integer/parseInt timeout)
                                (catch Exception _ 60000))
                           60000)
-        [header body]   (<?? (action-handler action* system action-param auth-map ledger request-timeout))
+        opts            (assoc params :timeout request-timeout)
+        [header body] (<?? (action-handler action* system action-param auth-map ledger opts))
         request-time    (- (System/nanoTime) start)
         resp-body       (json/stringify-UTF8 body)
         resp-headers    (reduce-kv (fn [acc k v]

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -492,7 +492,7 @@
                                (catch Exception _ 60000))
                           60000)
         opts            (assoc params :timeout request-timeout)
-        [header body] (<?? (action-handler action* system action-param auth-map ledger opts))
+        [header body]   (<?? (action-handler action* system action-param auth-map ledger opts))
         request-time    (- (System/nanoTime) start)
         resp-body       (json/stringify-UTF8 body)
         resp-headers    (reduce-kv (fn [acc k v]


### PR DESCRIPTION
This changes the transactor's reliance on the query peer's db message process and instead directly handles managing the current ledger state when acting as a transactor.
