### PR TITLE
FC-1274 Fix issue for signed requests where digest is not calculated on the original body content

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -112,10 +112,10 @@
 
 (defn decode-body
   [body type]
-  (let [^bytes body' (.bytes ^BytesInputStream body)]
+  (let [body' (-> ^BytesInputStream body .bytes (String. "UTF-8"))]
     (case type
-      :string (String. body' "UTF-8")
-      :json   (-> body' (String. "UTF-8") json/parse))))
+      :string body'
+      :json   (json/parse body'))))
 
 
 (defn- return-token

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -112,9 +112,10 @@
 
 (defn decode-body
   [body type]
-  (case type
-    :json (let [^bytes body' (.bytes ^BytesInputStream body)]
-            (-> body' (String. "UTF-8") json/parse))))
+  (let [^bytes body' (.bytes ^BytesInputStream body)]
+    (case type
+      :string (String. body' "UTF-8")
+      :json   (-> body' (String. "UTF-8") json/parse))))
 
 
 (defn- return-token
@@ -485,8 +486,9 @@
         start           (System/nanoTime)
         ledger          (keyword network db)
         action*         (keyword action)
-        action-param    (when body (decode-body body :json))
-        auth-map        (auth-map system ledger request action-param)
+        body'           (when body (decode-body body :string))
+        action-param    (some-> body' json/parse)
+        auth-map        (auth-map system ledger request body')
         request-timeout (if-let [timeout (:request-timeout headers)]
                           (try (Integer/parseInt timeout)
                                (catch Exception _ 60000))
@@ -660,11 +662,12 @@
 
 (defn delete-ledger
   [{:keys [conn] :as system} {:keys [body remote-addr] :as request}]
-  (let [body         (when body (decode-body body :json))
-        ledger-ident (:db/id body)
+  (let [body-str     (when body (decode-body body :string))
+        body'        (some-> body-str json/parse)
+        ledger-ident (:db/id body')
         [nw db]      (str/split ledger-ident #"/")
         ledger       (keyword nw db)
-        auth-map     (auth-map system ledger request body)
+        auth-map     (auth-map system ledger request body-str)
         session      (session/session conn [nw db])
         db*          (<?? (session/current-db session))
         ;; TODO - root role just checks if the auth has a role with id 'root' this can

--- a/test/fluree/db/ledger/api/downloaded.clj
+++ b/test/fluree/db/ledger/api/downloaded.clj
@@ -317,7 +317,7 @@
                                 (fn [result _ collection] (->> collection keys (into result)))
                                 #{}
                                 collections)
-          collection-names    (into #{} (map #(:name %) collections))]
+          collection-names    (set (map :name collections))]
 
       ; Are the keys in the collections what we expect?
       (is (test/contains-many? collection-keys :_id :name :version :doc))


### PR DESCRIPTION
Occasionally, the calculated digest did not match the digest provided in the header.   The body of a request first was converted from bytes into a string and then parsed into JSON.   The body was then re-stringified to calculate the digest.  The JSON->stringify operation may or may not retain the original order of contents.  

This impacted the following endpoints:
- fdb/delete-db
- fdb/network/db/{action} (e.g., fdb/myNetwork/ledgerOne/query)


With this fix, the digest is calculated on the original (stringified) body contents, prior to its conversion into JSON. 

Also, I added a test for a signed-multi-query that supplies its map contents in non-alphanumeric order.  This unit test failed prior to the changes. 

The unit test for the `delete-db ` endpoint will be submitted with another PR.  A change in processing was required to support an in-memory data store.  However, you cannot validate the digest calculation for delete-db without a closed api.