### PR TITLE
FC-1280 only invoke full-text indexer when process is defined on the connection

### DIFF
--- a/src/fluree/db/ledger/delete.clj
+++ b/src/fluree/db/ledger/delete.clj
@@ -65,9 +65,9 @@
   "Deletes the full-text (lucene) indexes for a ledger."
   [conn network dbid]
   (go-try
-    (let [indexer       (-> conn :full-text/indexer :process)
-          db            (<? (session/db conn (str network "/" dbid) nil))]
-      (<? (indexer {:action :forget, :db db})))))
+    (when-let [indexer (-> conn :full-text/indexer :process)]
+      (let [db (<? (session/db conn (str network "/" dbid) nil))]
+        (<? (indexer {:action :forget, :db db}))))))
 
 (defn process
   "Deletes a current DB, deletes block files."


### PR DESCRIPTION
While writing a unit test for delete ledger to validate changes on another ticket, I ran into an issue where the full-text indexer process was not defined. This is because the unit tests use in-memory storage for our data. 

Modified the delete-ledger code to not invoke the indexer process, unless it is defined.  This modification allows a `delete-db ` endpoint unit test to be included in our ci/cd.

Manually verified that full-text directories were cleaned up when submitting a _signed_ `delete-db` request in closed-api mode.