### PR TITLE
Fix ledger query-mode

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -242,7 +242,7 @@
 
 
   ;; Query Peer
-  (start {:fdb-connection-servers "localhost:8090"
+  (start {:fdb-query-peer-servers "localhost:8090"
           :fdb-api-port            8080
           :fdb-mode                "query"})
 

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -150,7 +150,7 @@
                                                         group
                                                         (assoc :group group))
                               servers           (when-not transactor?
-                                                  (:fdb-connection-servers settings))
+                                                  (:fdb-query-peer-servers settings))
                               conn-impl         (connection/connect servers conn-opts)
                               full-text-indexer (full-text/start-indexer conn-impl)]
                           ;; launch message consumer, handles messages back from ledger

--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -24,7 +24,7 @@
 (def default-env
   {:fdb-mode                     "query"                    ;; dev, query, ledger
    :fdb-join?                    false                      ;; set to true when server is joining an existing/running network
-   :fdb-connection-servers       "localhost:8090"           ;; servers to connect to while in query mode
+   :fdb-query-peer-servers       "localhost:8090"           ;; servers to connect to while in query mode
    :fdb-license-key              nil
    :fdb-consensus-type           "raft"                     ;; raft
    :fdb-encryption-secret        nil                        ;; Text encryption secret for encrypting data at rest and in transit


### PR DESCRIPTION
Query mode is for running a ledger without a transactor, just a query server. The
problem was that we were initializing the query server connection with a custom
:storage-read function that would look to the local ledger server for data, instead of
the remote ledger group. This was fixed by relying on the fluree db's default
:storage-read function, which properly connects to the remote ledger group.

In query mode we were also throwing periodic exceptions as we were trying to collect
ledger stats from the (nonexistant) local ledger group. Now we initiate-stats-reporting
only when we are starting a transactor.

I've also added a couple of additional checks so that users do not need to specify
:fdb-group-servers in the config for a query-mode peer, since that is unused in this
mode.

FC-631