### PR TITLE
FC-1291 Fix/new db blocking

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.1"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "595f959e35e2bebdf760ae67964cb64043b5a5e2"}
+                                           :sha "29bb36767c7823c9b78020c15266da797651878e"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.6"}
 

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -223,15 +223,13 @@
                                              (catch-build-block-exception conn network block-map*) ;; will return nil if exception
                                              (merge-tx-into-block block-map*))
                     reindexed-db    (indexing/reindexed-db session)
-                    novelty-max?    (indexing/novelty-max? session (:db-after block-result))
-                    ;; if at novelty-max, need to wait for indexing to complete before proceeding
                     block-result*   (when block-result
                                       (cond
                                         reindexed-db
                                         (<? (indexing/merge-new-index session block-result reindexed-db))
 
                                         ;; at novelty-max - may or may not be a reindex in process. Need to wait.
-                                        novelty-max?
+                                        (indexing/novelty-max? session (:db-after block-result))
                                         (<? (indexing/novelty-max-block session block-result))
 
                                         :else

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -318,6 +318,7 @@ or this server is not responsible for this ledger, will return false. Else true 
 
 
 (defn block-height*
+  "Returns block height given the group's state atom."
   [group-state network ledger-id]
   (get-in group-state [:networks network :dbs ledger-id :block]))
 
@@ -339,18 +340,6 @@ or this server is not responsible for this ledger, will return false. Else true 
    (register-genesis-block-async group network ledger-id 1))
   ([group network ledger-id block]
    (kv-assoc-in-async group [:networks network :dbs ledger-id :block] block)))
-
-(defn next-block
-  "Returns next block for given ledger if one is proposed."
-  [group network ledger-id]
-  (get-in (-local-state group) [:networks network :dbs ledger-id :next-block]))
-
-(defn set-next-block-async
-  "Sets next block, ensures current state is still at existing block."
-  [raft network ledger-id next-block-data current-block]
-  (let [compare-ks [network :dbs ledger-id :block]
-        compare-v  current-block]
-    (kv-cas-in-async raft [:networks network :dbs ledger-id :next-block] next-block-data compare-ks compare-v)))
 
 
 ;; storage commands

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -918,26 +918,3 @@
                         (reset! web-server nil))]
       (map->WebServer {:close close-fn}))))
 
-
-
-(comment
-  (def opts {:enabled true :system user/system :port 8090})
-
-  (webserver-factory opts)
-
-
-  (defn handler [req]
-    {:status  200
-     :headers {"content-type" "text/plain"}
-     :body    "hello!"})
-
-  (def server5 (http/run-server handler {:port 8090}))
-
-  (type server)
-
-  (do
-    ;(.close server4)
-    (server5 :timeout 1000))
-
-
-  (.close server5))

--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -383,7 +383,8 @@
          :ledger-info (let [[network dbid] (session/resolve-ledger (:conn system) arg)]
                         (success! (ledger-info system network dbid)))
 
-         :ledger-stats (future (ledger-stats system arg success! error!)) ;; as thread, as it will create new message calls if having to load db, and will block
+         :ledger-stats (future                              ;; as thread/future - otherwise if this needs to load new db will have new requests and will permanently block
+                         (ledger-stats system arg success! error!))
 
          ;; TODO - change command and all internal calls to :ledger-list, deprecate :db-list
          :db-list (let [response (txproto/ledger-list (:group system))]


### PR DESCRIPTION
This is the fluree/ledger counterpart to fluree/db changes to address this issue. Changes include:
- Remove blocking calls in message processor, which was deadlocking some operations coming from http-api (admin UI)
- Add :group to connection object itself instead of after-the-fact, simplify system startup slightly
- Potential error condition with novelty-max if block has no transactions
- Create map of recently processed commands to ensure command never processed twice even if delayed by consensus
- Streamlined block creation loop - fix a possible error condition where fatal error processing block could indicate exiting transactor loop however never exits