### PR TITLE
Fix the health check on query peers

### DIFF
--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -677,7 +677,7 @@
                    :meta        {:hostname hostname}}
      ;:version  fdb-version
 
-     :group       (build-group-settings settings group-servers)
+     :group       (when is-ledger? (build-group-settings settings group-servers))
      :consensus   (when is-ledger? {:type    consensus-type
                                     :options (case consensus-type
                                                :raft (raft-transactor-settings settings)


### PR DESCRIPTION
The health handler (fluree.db.peer.server-api/health-handler) attempts to get the local
transactor group's status when it has a group settings. This fails because there is no
group in query-mode.

The fix is to not even attempt to build group settings when starting a query peer.

FC-1299