### PR TITLE
Change the open-api check to look at the webserver config

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -164,7 +164,7 @@
 
 (defn open-api?
   [system]
-  (-> system :group :open-api))
+  (-> system :config :webserver :open-api))
 
 
 (defn authenticated?


### PR DESCRIPTION
Before, we checked the ledger's group settings to see if it has an open api or not. In a
query peer, there are no group settings. Instead, we should check if the webserver has
been configured to have an open api.

FC-1300