### PR TITLE
FC-1305: don't try to sync the index if all blocks are registered

### DIFF
--- a/src/fluree/db/ledger/indexing/full_text.clj
+++ b/src/fluree/db/ledger/indexing/full_text.clj
@@ -232,7 +232,7 @@
                          dbid))
           (write-range idx wrtr db first-block last-block))
       (do (log/info "Full text index up to date")
-          (async/to-chan [])))))
+          (async/to-chan! [])))))
 
 (defn full-reset
   [idx wrtr db]

--- a/src/fluree/db/ledger/indexing/full_text.clj
+++ b/src/fluree/db/ledger/indexing/full_text.clj
@@ -226,10 +226,13 @@
                          (or 0))
         first-block  (inc last-indexed)
         last-block   block]
-    (log/info (str "Syncing full text index from block: " first-block
-                   " to block " last-block " for ledger " network "/"
-                   dbid))
-    (write-range idx wrtr db first-block last-block)))
+    (if (<= first-block last-block)
+      (do (log/info (str "Syncing full text index from block: " first-block
+                         " to block " last-block " for ledger " network "/"
+                         dbid))
+          (write-range idx wrtr db first-block last-block))
+      (do (log/info "Full text index up to date")
+          (async/to-chan [])))))
 
 (defn full-reset
   [idx wrtr db]


### PR DESCRIPTION
My previous patch caused an error to show up in the logs during dbsync when the full text index is up to date due to block-range calls where the start block ended up being greater than the end block. Block range happily returns a reversed sequence of blocks in this case, but the indexer throws the error when trying to index blocks out of order. This does not affect ledger startup as the blocks are already indexed, but this patch ensures the error isn't thrown in this case to clean up the logs. It does this by short circuiting sync if the index is up to date. 