### PR TITLE
Fix: slow down nw state timeout test (FC-1316)

### DIFF
--- a/src/fluree/db/peer/server_health.clj
+++ b/src/fluree/db/peer/server_health.clj
@@ -66,8 +66,8 @@
       (let [[k v] cq
             acc* (into acc [{(keyword k) (count v)
                              :txn-count  (count v)
-                             :txn-oldest-instant (some->> v vals (map :instant) (apply min))
-                             }])]
+                             :txn-oldest-instant (some->> v vals (map :instant) (apply min))}])]
+
         (recur r acc*))
       acc)))
 
@@ -188,5 +188,5 @@
       {:status  http-timeout
        :headers {"Content-Type" "text/plain"}
        :body    (->> timeout
-                     (format "Client Timeout. Request did not complete in %d ms" )
+                     (format "Client Timeout. Request did not complete in %d ms")
                      json/stringify-UTF8)})))

--- a/test/fluree/db/peer/server_health_tests.clj
+++ b/test/fluree/db/peer/server_health_tests.clj
@@ -9,12 +9,12 @@
 (def ^:const instant-now (System/currentTimeMillis))
 (def ^:const instant-oldest-txn (- instant-now 5000))
 (def ^:const state-leases {:servers {:server-id {:id :DEF :expire (+ instant-now 300000)}}})
-(def ^:const state-cmd-queue {"test" {"txid" {:data    {:cmd "" :sig ""}
-                                              :size    400
-                                              :txid    "txid"
-                                              :network "network"
-                                              :dbid    "dbid"
-                                              :instant instant-oldest-txn}}
+(def ^:const state-cmd-queue {"test"   {"txid" {:data    {:cmd "" :sig ""}
+                                                :size    400
+                                                :txid    "txid"
+                                                :network "network"
+                                                :dbid    "dbid"
+                                                :instant instant-oldest-txn}}
                               "fluree" {"txid" {:data    {:cmd "" :sig ""}
                                                 :size    2400
                                                 :txid    "txid"
@@ -27,8 +27,8 @@
 
 (deftest server-health-tests
   (testing "remove-deep"
-    (let [original {:level-1 {:level-2 {:private-key "abcd" :other "1234"}
-                              :private-key "4567"}
+    (let [original {:level-1     {:level-2     {:private-key "abcd" :other "1234"}
+                                  :private-key "4567"}
                     :private-key "7890"}
           expected {:level-1 {:level-2 {:other "1234"}}}]
       (is (= expected (srv-health/remove-deep [:private-key] original)))))


### PR DESCRIPTION
Closes FC-1316

Feel free to ignore bba1fa4ed7e85d0d0ef4812eaae611019a95cbbe it's just some formatting / whitespace cleanups. All of the interesting changes are in bba1fa4ed7e85d0d0ef4812eaae611019a95cbbe.