### PR TITLE
Fix/unresolved remote addr

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -282,6 +282,30 @@
   (stop-one ledger-peer)
   (stop-one query-peer)
 
+  (def ledger1 (start-one {:fdb-api-port            8091
+                           :fdb-mode                "ledger"
+                           :fdb-group-servers       "ledger1@server1.local:9791,ledger2@server2.local:9792,ledger3@server3.local:9793"
+                           :fdb-group-this-server   "ledger1"
+                           :fdb-group-log-directory "./data/ledger1/data/group"
+                           :fdb-storage-file-root   "./data/ledger1/data"}))
+  (def ledger2 (start-one {:fdb-api-port            8092
+                           :fdb-mode                "ledger"
+                           :fdb-group-servers       "ledger1@server1.local:9791,ledger2@server2.local:9792,ledger3@server3.local:9793"
+                           :fdb-group-this-server   "ledger2"
+                           :fdb-group-log-directory "./data/ledger2/data/group"
+                           :fdb-storage-file-root   "./data/ledger2/data"}))
+  (def ledger3 (start-one {:fdb-api-port            8093
+                           :fdb-mode                "ledger"
+                           :fdb-group-servers       "ledger1@server1.local:9791,ledger2@server2.local:9792,ledger3@server3.local:9793"
+                           :fdb-group-this-server   "ledger3"
+                           :fdb-group-log-directory "./data/ledger3/data/group"
+                           :fdb-storage-file-root   "./data/ledger3/data"}))
+
+  (stop-one ledger1)
+  (stop-one ledger2)
+  (stop-one ledger3)
+
+
 
   ;; Three servers
   (start {:fdb-group-servers       "ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792"

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -881,7 +881,7 @@
       ignore-trailing-slash))
 
 
-(defonce web-server (atom nil))
+(defonce web-server (atom {}))
 
 (defrecord WebServer [close])
 
@@ -901,9 +901,9 @@
                                     :open-api open-api)
           _           (try
                         (json/encode-BigDecimal-as-string json-bigdec-string)
-                        (reset! web-server (http/run-server
-                                             (make-handler system*)
-                                             {:port port}))
+                        (swap! web-server assoc port (http/run-server
+                                                       (make-handler system*)
+                                                       {:port port}))
                         (catch BindException _
                           (log/error (str "Cannot start. Port binding failed, address already in use. Port: " port "."))
                           (log/error "FlureeDB Exiting. Adjust your config, or shut down other service using port.")
@@ -914,7 +914,8 @@
                           (System/exit 1)))
           close-fn    (fn []
                         ;; shut down the web server but give existing connections 1s to finish
-                        (@web-server :timeout 1000)
-                        (reset! web-server nil))]
+                        (let [server-close-fn (get @web-server port)]
+                          (server-close-fn :timeout 1000))
+                        (swap! web-server dissoc port))]
       (map->WebServer {:close close-fn}))))
 

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -73,7 +73,7 @@
       (try-continue (:close full-text-indexer)))
     (when (fn? (:close conn))
       (try-continue (:close conn)))
-    (ftcp/shutdown-client-event-loop)))
+    (ftcp/shutdown-client-event-loop (:this-server group))))
 
 
 (defn check-version-upgrade-fn
@@ -165,7 +165,7 @@
                                                  (assoc :system system))]
                           (http-api/webserver-factory webserver-opts))
          ;; we are not a transacting peer in query mode, don't bother with this
-         stats          (when transactor? (stats/initiate-stats-reporting system (-> config :stats :interval)))
+         stats          (stats/initiate-stats-reporting system (-> config :stats :interval))
          system*        (assoc system :webserver webserver
                                :stats stats)
          _              (when (and (or memory? (= consensus-type :in-memory))


### PR DESCRIPTION
This is something I cooked up with @jakep36 to solve the issue laid out in https://fluree.atlassian.net/browse/FC-1320

The gist of the problem is that if a remote server in the `:fdb-group-servers` config has an unresolvable hostname, then the tcp thread crashes when we try to connect to it. This fixes that by just spinning until the remote host is resolveable.

This is the simplest fix that we could come up with that addresses the issue, but that doesn't mean there can't be better approaches, so advice is welcome there.

Another question is if we should make this configurable - I don't know why we wouldn't want this behavior, but maybe we want to configure the retry strategy in some way. Feedback welcome.