### PR TITLE
Only docker build on host platform; run on requested

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:tools-deps-1.10.3.998-slim-bullseye AS builder
+FROM --platform=$BUILDPLATFORM clojure:openjdk-11-tools-deps-1.10.3.1040-slim-bullseye AS builder
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl
 
@@ -20,7 +20,7 @@ COPY . ./
 RUN make uberjar
 RUN make stage-release
 
-FROM openjdk:11 AS runner
+FROM openjdk:17-slim-bullseye AS runner
 
 RUN mkdir -p /opt/fluree
 COPY --from=builder /usr/src/fluree-ledger/build/* /opt/fluree/

--- a/script/run-in-docker.sh
+++ b/script/run-in-docker.sh
@@ -11,5 +11,5 @@ export DOCKER_BUILDKIT=1
 # output build stdout to /dev/null b/c even with --quiet it still outputs
 # sha256:blahblahblah and we sometimes want to consume the docker run output
 # in another script
-docker build --quiet --target builder --tag "${builder_image}" --load . >/dev/null
-docker run --rm "${DOCKER_RUN_ARGS}" "${builder_image}" "$@"
+docker build --quiet --target builder --tag "${builder_image}" . >/dev/null
+docker run --rm ${DOCKER_RUN_ARGS} "${builder_image}" "$@"

--- a/script/run-in-docker.sh
+++ b/script/run-in-docker.sh
@@ -11,5 +11,5 @@ export DOCKER_BUILDKIT=1
 # output build stdout to /dev/null b/c even with --quiet it still outputs
 # sha256:blahblahblah and we sometimes want to consume the docker run output
 # in another script
-docker build --quiet --target builder --tag "${builder_image}" . >/dev/null
+docker build --quiet --target builder --tag "${builder_image}" --load . >/dev/null
 docker run --rm "${DOCKER_RUN_ARGS}" "${builder_image}" "$@"

--- a/script/run-in-docker.sh
+++ b/script/run-in-docker.sh
@@ -6,8 +6,10 @@ image=fluree/${PWD##*/}
 
 builder_image=${image}:builder
 
+export DOCKER_BUILDKIT=1
+
 # output build stdout to /dev/null b/c even with --quiet it still outputs
 # sha256:blahblahblah and we sometimes want to consume the docker run output
 # in another script
 docker build --quiet --target builder --tag "${builder_image}" . >/dev/null
-docker run --rm ${DOCKER_RUN_ARGS} "${builder_image}" "$@"
+docker run --rm "${DOCKER_RUN_ARGS}" "${builder_image}" "$@"


### PR DESCRIPTION
I realized that we were being very inefficient in our Docker builds of ledger b/c the build phase was platform agnostic (it's all Java bytecode, HTML, JS, etc.) but we were building on every requested platform. Adding the `--platform=$BUILDPLATFORM` flag to the builder FROM line fixes this. It runs the build once on the non-emulated builder host's platform (fast & reliable) but then wraps the result in a platform-appropriate openjdk image for the runner (simple & fast even under emulation b/c it isn't doing that much). All we really need is for the `java` binary in the final image to be platform-appropriate, and this still does that. I tested the resulting image on both linux/arm64 and linux/amd64 and they seemed to work just fine.