### PR TITLE
FC-1332 - Remove host from signing strings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:deps {org.clojure/clojure               {:mvn/version "1.10.3"}
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
-        com.fluree/db                     {:mvn/version "1.0.0-rc34"}
+        com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
+                                           :sha "de215a07f54eb316eed1cda8555a2cc2c20ca6e8"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/src/fluree/db/ledger/bootstrap.clj
+++ b/src/fluree/db/ledger/bootstrap.clj
@@ -154,7 +154,7 @@
      (flake/new-flake role-sid (get pred->id "_role/doc") "Root role." t true)
      (flake/new-flake role-sid (get pred->id "_role/rules") rule-sid t true)
 
-     ;; add auth record, and assign root rule
+     ;; add auth record, and assign root role
      (flake/new-flake auth-subid (get pred->id "_auth/id") master-authority t true)
      (flake/new-flake auth-subid (get pred->id "_auth/roles") role-sid t true)
 

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -168,14 +168,14 @@
 
 
 (defn authenticated?
-  "Returns truthy if either open-api is enable or user is authenticated"
+  "Returns truthy if either open-api is enabled or user is authenticated"
   [system auth-map]
   (or (open-api? system)
       (:auth auth-map)))
 
 
 (defn- require-authentication
-  "Will throw if request if not authenticated"
+  "Will throw if request is not authenticated"
   [system auth-map]
   (when-not (authenticated? system auth-map)
     (throw (ex-info (str "Request requires authentication.")
@@ -184,7 +184,7 @@
 
 
 (defn- strict-authentication
-  "Will throw if request if not authenticated, and if the auth-id isn't
+  "Will throw if request is not authenticated, and if the auth-id isn't
   currently within the system. Returns a core async channel."
   [system auth-map]
   (go-try
@@ -737,16 +737,11 @@
                         auth-id          (cond
 
                                            signature
-                                           (let [this-server (get-in system [:group :this-server])
-                                                 servers     (get-in system [:config :group :server-configs])
-                                                 host        (-> (filter (fn [n] (= (:server-id n) this-server)) servers)
-                                                                 first :host)
-
-                                                 {:keys [auth authority]} (http-signatures/verify-request*
+                                           (let [{:keys [auth authority]} (http-signatures/verify-request*
                                                                             {:headers headers} :get
                                                                             (str "/fdb/storage/" network "/" db
                                                                                  (when type (str "/" type))
-                                                                                 (when key (str "/" key))) host)
+                                                                                 (when key (str "/" key))))
                                                  db          (<? (fdb/db (:conn system) db-name))]
                                              (<? (verify-auth db auth authority)))
 


### PR DESCRIPTION
In FC-303 we decided to stop including the host parameter in http signature signing strings. While developing the fluhrbee http-api proxy I found some places where we were still assuming that would be included. This PR and [its counterpart in db](https://github.com/fluree/db/pull/140) removes those too.

Part of FC-1332