### PR TITLE
Persist default private key in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,8 @@ EXPOSE 8090
 # Point runtime data paths at volume
 ENV FLUREE_ARGS="-Dfdb-storage-file-root=/var/lib/fluree/ -Dfdb-group-log-directory=/var/lib/fluree/group/"
 
+# Persist default-private-key.txt in the same volume as the data
+ENV FLUREE_ARGS="${FLUREE_ARGS} -Dfdb-group-config-path=/var/lib/fluree/"
+
 ENTRYPOINT ["./fluree_start.sh"]
 CMD []


### PR DESCRIPTION
If you create a Docker image and persist the data in the `/var/lib/fluree` volume, it's easy to lose access to it because the auto-generated `default-private-key.txt` was stored elsewhere in the image.

This fixes that by telling Fluree to store it alongside the data in `/var/lib/fluree/default-private-key.txt`.

Closes FC-1331