### PR TITLE
FC-1330 - Add /fdb/command endpoint for new-db (mostly)

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -829,12 +829,12 @@
         ledger       (some-> cmd :ledger keyword)
         timeout      (or (:request-timeout headers) 60000)
         opts         {:timeout timeout}
-        _            (log/info "Sending command:" (pr-str cmd))
+        _            (log/debug "Sending command:" (pr-str cmd))
         [headers body] (<?? (action-handler :command system cmd nil ledger
                                             opts))
         request-time (- (System/nanoTime) start)]
-    (log/info "Command result:" (pr-str body))
-    (log/info "Command response headers:" (pr-str headers))
+    (log/debug "Command result:" (pr-str body))
+    (log/debug "Command response headers:" (pr-str headers))
     {:status  (or (:status headers) 200)
      :headers (-> headers
                   (assoc :time (format "%.2fms" (float (/ request-time 1000000)))

--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -42,6 +42,7 @@
         auth-id  (try
                    (crypto/account-id-from-message cmd sig)
                    (catch Exception _ (throw-invalid-command "Invalid signature on command.")))]
+    (log/trace "Processing signed command:" (pr-str cmd-data))
     (case cmd-type
       :tx (let [{:keys [db tx deps expire nonce]} cmd-data
                 _ (when-not db (throw-invalid-command "No db specified for transaction."))


### PR DESCRIPTION
We need an API route that doesn't embed network/ledger in the path for new-db b/c it doesn't exist yet there and will be specified inside the command itself.

Tested this with a (locally modified; separate PR incoming) flurl that signs commands sent to this endpoint. In theory this supports any command, but I tested it with `new-db` as that was the primary (only?) one that didn't already have a ledger to reference.

Part of FC-1330