### PR TITLE
FC-1343: check for reindex flag in settings instead of system

### DIFF
--- a/src/fluree/db/ledger/reindex.clj
+++ b/src/fluree/db/ledger/reindex.clj
@@ -195,3 +195,14 @@
                    (txproto/write-index-point-async group db**)
                    (recur (inc block) db**))
                  (recur (inc block) db*))))))))))
+
+(defn reindex-all
+  [conn]
+  (go-try
+   (doseq [[network dbid] (->> conn
+                               txproto/ledgers-info-map
+                               (map (juxt :network :ledger)))]
+     (log/info "Rebuilding indexes for ledger [" network dbid "]")
+     (let [status (<? (reindex conn network dbid))]
+       (log/info "Ledger rebuilding complete for ledger [" network dbid "]"
+                 status)))))


### PR DESCRIPTION
This patch checks for the reindex flag on the settings used to start the system because the flag wasn't persisting through system startup. 