### PR TITLE
Use db.util.log everywhere consistently

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         ;com.fluree/db                     {:mvn/version "1.0.0-rc34"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "542431e8492612ec2cedc6fd942ed1a548ace70f"}
+                                           :sha "b27acb7d41f673c255db685525f553613b81e87c"}
         ;com.fluree/db                     {:local/root "../db"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         ;com.fluree/db                     {:mvn/version "1.0.0-rc34"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "b27acb7d41f673c255db685525f553613b81e87c"}
+                                           :sha "5c94a8c7f6057529129f53258a9fd808e226b30e"}
         ;com.fluree/db                     {:local/root "../db"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}

--- a/src/fluree/db/ledger/consensus/dbsync2.clj
+++ b/src/fluree/db/ledger/consensus/dbsync2.clj
@@ -2,7 +2,7 @@
   (:require [fluree.db.storage.core :as storage]
             [fluree.db.ledger.storage :as ledger-storage]
             [clojure.core.async :as async :refer [go <! >!]]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [fluree.db.ledger.storage.filestore :as filestore]
             [fluree.db.ledger.util :as util :refer [go-try <?]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]

--- a/src/fluree/db/ledger/consensus/tcp.clj
+++ b/src/fluree/db/ledger/consensus/tcp.clj
@@ -3,7 +3,7 @@
             [clojure.core.async :as async]
             [taoensso.nippy :as nippy]
             [fluree.db.util.async :refer [go-try]]
-            [clojure.tools.logging :as log])
+            [fluree.db.util.log :as log])
   (:import (java.net BindException InetSocketAddress)))
 
 (set! *warn-on-reflection* true)
@@ -116,7 +116,7 @@
             :else
             (do
               (log/info "Waiting to initialize connection, but did not contain proper initialize message"
-                        (or data (pr-str initial-msg)))
+                        (or data initial-msg))
               (recur))))))))
 
 
@@ -195,8 +195,8 @@
               (try
                 (handler conn msg)
                 (catch Exception e
-                  (log/error e (str "Error executing handler function for incoming message from client: "
-                                    (or (:to conn) remote-server) ". Message: " (pr-str msg)))))
+                  (log/error e "Error executing handler function for incoming message from client:"
+                             (or (:to conn) remote-server) "Message:" msg)))
               (recur conn))))))))
 
 ;; store client event loop here to be shared across all client connections
@@ -236,7 +236,7 @@
   (loop [retries 0]
     (let [addr (InetSocketAddress. ^String host ^Integer port)]
       (if (.isUnresolved addr)
-        (do (log/warn (str "Remote server address is not resolvable:" host ":" port ". Retrying (" retries ").") )
+        (do (log/warn (str "Remote server address is not resolvable:" host ":" port ". Retrying (" retries ")."))
             (Thread/sleep 5000)
             (recur (inc retries)))
         addr))))

--- a/src/fluree/db/ledger/garbage_collect.clj
+++ b/src/fluree/db/ledger/garbage_collect.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.garbage-collect
   (:require [fluree.db.storage.core :as storage]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [clojure.string :as str]
             [fluree.db.util.async :refer [go-try <?]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]))

--- a/src/fluree/db/ledger/indexing/full_text.clj
+++ b/src/fluree/db/ledger/indexing/full_text.clj
@@ -4,7 +4,7 @@
             [fluree.db.query.range :as query-range]
             [fluree.db.util.schema :as schema]
             [clojure.core.async :as async :refer [<! chan go go-loop]]
-            [clojure.tools.logging :as log])
+            [fluree.db.util.log :as log])
   (:import (fluree.db.flake Flake)
            (java.time Instant)
            (java.io Closeable)))

--- a/src/fluree/db/ledger/reindex.clj
+++ b/src/fluree/db/ledger/reindex.clj
@@ -1,5 +1,5 @@
 (ns fluree.db.ledger.reindex
-  (:require [clojure.tools.logging :as log]
+  (:require [fluree.db.util.log :as log]
             [fluree.db.storage.core :as storage]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.flake :as flake]

--- a/src/fluree/db/ledger/stats.clj
+++ b/src/fluree/db/ledger/stats.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.stats
   (:require [clojure.core.async :as async]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
             [clojure.walk :as walk]
             [clojure.string :as str]

--- a/src/fluree/db/ledger/storage/crypto.clj
+++ b/src/fluree/db/ledger/storage/crypto.clj
@@ -1,5 +1,5 @@
 (ns fluree.db.ledger.storage.crypto
-  (:require [clojure.tools.logging :as log]
+  (:require [fluree.db.util.log :as log]
             [fluree.crypto :as crypto])
   (:import (java.nio ByteBuffer)
            (java.security SecureRandom)

--- a/src/fluree/db/ledger/storage/filestore.clj
+++ b/src/fluree/db/ledger/storage/filestore.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.ledger.storage.filestore
   (:require [clojure.java.io :as io]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [clojure.core.async :as async]
             [fluree.db.ledger.storage :refer [key->unix-path]]
             [fluree.db.ledger.storage.crypto :as crypto])

--- a/src/fluree/db/ledger/storage/s3store.clj
+++ b/src/fluree/db/ledger/storage/s3store.clj
@@ -6,7 +6,7 @@
             [cognitect.aws.client.api :as aws]
             [fluree.db.ledger.storage :refer [key->unix-path]]
             [fluree.db.ledger.storage.crypto :as crypto]
-            [clojure.tools.logging :as log])
+            [fluree.db.util.log :as log])
   (:import (java.io ByteArrayOutputStream Closeable)))
 
 (set! *warn-on-reflection* true)
@@ -135,7 +135,7 @@
                               :size size})
                            objects)]
        (log/trace (format "Objects found in %s bucket at %s: %s"
-                          bucket path' (pr-str result)))
+                          bucket path' result))
        (with-meta result (dissoc s3-result :Contents))))))
 
 

--- a/src/fluree/db/ledger/transact.clj
+++ b/src/fluree/db/ledger/transact.clj
@@ -1,5 +1,5 @@
 (ns fluree.db.ledger.transact
-  (:require [clojure.tools.logging :as log]
+  (:require [fluree.db.util.log :as log]
             [fluree.db.flake :as flake]
             [fluree.db.dbproto :as dbproto]
             [fluree.db.util.core :as util]
@@ -250,7 +250,7 @@
                   :else
                   (do
                     (log/warn "Proposed block was not accepted by the network because: "
-                              (pr-str block-approved?)
+                              block-approved?
                               "Proposed block: "
                               (dissoc block-result* :db-orig :db-before :db-after))
                     false)))

--- a/src/fluree/db/ledger/transact/validation.clj
+++ b/src/fluree/db/ledger/transact/validation.clj
@@ -510,7 +510,7 @@
             (->> errors
                  (map #(let [ex (ex-data %)]
                          (when (= 500 (:status ex))
-                           (log/error % "Unexpected validation error in transaction! Flakes:" (pr-str all-flakes)))
+                           (log/error % "Unexpected validation error in transaction! Flakes:" all-flakes))
                          (assoc ex :message (ex-message %))))
                  (not-empty))
 
@@ -587,7 +587,7 @@
                 (->> errors
                      (map #(let [ex (ex-data %)]
                              (when (= 500 (:status ex))
-                               (log/error % "Unexpected validation error in transaction! Flakes:" (pr-str all-flakes)))
+                               (log/error % "Unexpected validation error in transaction! Flakes:" all-flakes))
                              (assoc ex :message (ex-message %))))
                      (not-empty))
 

--- a/src/fluree/db/ledger/txgroup/core.clj
+++ b/src/fluree/db/ledger/txgroup/core.clj
@@ -1,7 +1,7 @@
 (ns fluree.db.ledger.txgroup.core
   (:require [fluree.db.ledger.consensus.raft :as raft]
             [fluree.db.ledger.consensus.none :as none]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]))
 
 (set! *warn-on-reflection* true)
@@ -101,7 +101,7 @@
                       :in-memory (none/launch-in-memory-server group-settings))]
 
 
-    (log/debug "Start-group. Settings are: " (pr-str group-settings))
+    (log/debug "Start-group. Settings are: " group-settings)
     group))
 
 (defn data-version

--- a/src/fluree/db/ledger/txgroup/monitor.clj
+++ b/src/fluree/db/ledger/txgroup/monitor.clj
@@ -1,5 +1,5 @@
 (ns fluree.db.ledger.txgroup.monitor
-  (:require [clojure.tools.logging :as log]
+  (:require [fluree.db.util.log :as log]
             [clojure.set :as set]
             [clojure.core.async :as async]
             [fluree.db.session :as session]
@@ -386,7 +386,7 @@
   - command - the command data/payload which is a vector of [op & args]
   - result - the state-machines result response after applying this command"
   [system state-change]
-  (log/trace "State change in tx-group: " (pr-str state-change))
+  (log/trace "State change in tx-group:" state-change)
   (let [op   (get-in state-change [:command 0])
         conn (:conn system)]
     (case op

--- a/src/fluree/db/ledger/upgrade/full_text.clj
+++ b/src/fluree/db/ledger/upgrade/full_text.clj
@@ -6,7 +6,7 @@
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
             [fluree.db.query.range :as query-range]
             [clojure.core.async :as async :refer [<!!]]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [environ.core :as environ])
   (:import (fluree.db.flake Flake)))
 

--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -1,6 +1,6 @@
 (ns fluree.db.peer.messages
   (:require [alphabase.core :as ab-core]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [clojure.core.async :as async]
             [clojure.string :as str]
             [fluree.db.util.json :as json]
@@ -29,7 +29,8 @@
   throws."
   [{:keys [conn] :as system}  {:keys [cmd sig] :as signed-cmd}]
   (when-not (and (string? cmd) (string? sig))
-    (throw-invalid-command (str "Command map requires keys of 'cmd' and 'sig', with a json string command map and signature of the command map respectively. Provided: " (pr-str signed-cmd))))
+    (throw-invalid-command (str "Command map requires keys of 'cmd' and 'sig', with a json string command map and signature of the command map respectively. Provided: "
+                                (pr-str signed-cmd))))
   (when (> (count cmd) 10000000)
     (throw-invalid-command (format "Command is %s bytes and exceeds the configured max size." (count cmd))))
   (let [id       (crypto/sha3-256 cmd)
@@ -226,9 +227,9 @@
                                       :error   error}]
                       ;; log any unexpected errors locally
                       (when (>= status 500)
-                        (log/error e (str "Unexpected error processing message: " (pr-str msg))))
+                        (log/error e "Unexpected error processing message:" msg))
                       (async/put! producer-chan [:response req-id nil error-resp])))]
-     (log/trace "Incoming message: " (pr-str msg))
+     (log/trace "Incoming message:" msg)
      (try
        (case (keyword operation)
          :close (do ;; close will trigger the on-closed callback and clean up all session info.

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -1,7 +1,7 @@
 (ns fluree.db.server
   (:gen-class)
   (:require [environ.core :as environ]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [clojure.core.async :as async]
             [clojure.string :as str]
 
@@ -66,7 +66,7 @@
         try-continue (fn [f]
                        (try (f)
                             (catch Exception e
-                              (log/error e "Exception executing close function: " (pr-str f)))))]
+                              (log/error e "Exception executing close function: " f))))]
     (when (fn? (:close webserver))
       (try-continue (:close webserver)))
     (try-continue (fn [] (async/close! stats)))
@@ -132,13 +132,13 @@
 (defn startup
   ([] (startup (settings/build-env @environ/runtime-env)))
   ([settings]
-   (log/info (str "Starting Fluree in mode: " (:fdb-mode settings)))
+   (log/info "Starting Fluree in mode:" (:fdb-mode settings))
    (log/info "Starting with config:\n" (with-out-str
                                          (pprint/pprint
                                            (cond-> (into (sorted-map) settings) ;; hide encryption secret from logs
                                                    (:fdb-encryption-secret settings) (assoc :fdb-encryption-secret "prying eyes want to know...")))))
-   (log/info "JVM arguments: " (str (stats/jvm-arguments)))
-   (log/info "Memory Info: " (stats/memory-stats))
+   (log/info "JVM arguments:" (stats/jvm-arguments))
+   (log/info "Memory Info:" (stats/memory-stats))
 
    (Thread/setDefaultUncaughtExceptionHandler
     (reify Thread$UncaughtExceptionHandler

--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -1,7 +1,7 @@
 (ns fluree.db.server-settings
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
-            [clojure.tools.logging :as log]
+            [fluree.db.util.log :as log]
             [fluree.db.util.core :as util]
             [fluree.db.ledger.storage.filestore :as filestore]
             [fluree.db.ledger.storage.memorystore :as memorystore]


### PR DESCRIPTION
...now that it is macros and preserves the calling ns in logs

NB: No need to pr-str anything w/ db.util.log, it does it for you

Companion PR to https://github.com/fluree/db/pull/142