### PR TITLE
FC-1342 - Feature: multiple root ledger owners

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         ;com.fluree/db                     {:mvn/version "1.0.0-rc34"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "048d83ab421f70dad646166312525d175847dfac"}
+                                           :sha "1c005351bd9a049745c329b6c09659b30d84afb6"}
         ;com.fluree/db                     {:local/root "../db"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         ;com.fluree/db                     {:mvn/version "1.0.0-rc34"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "bb66fbbc3d8c6ca06d8238396fe5993c74dd7705"}
+                                           :sha "048d83ab421f70dad646166312525d175847dfac"}
         ;com.fluree/db                     {:local/root "../db"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}

--- a/deps.edn
+++ b/deps.edn
@@ -35,6 +35,8 @@
 
  :paths ["src" "resources"]
 
+ :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]
+
  :aliases
  {:mvn/group-id com.fluree
   :mvn/artifact-id ledger

--- a/deps.edn
+++ b/deps.edn
@@ -16,17 +16,17 @@
 
         ;; AWS S3 API
         com.cognitect.aws/api             {:mvn/version "0.8.539"}
-        com.cognitect.aws/endpoints       {:mvn/version "1.1.12.129"}
-        com.cognitect.aws/s3              {:mvn/version "814.2.991.0"}
+        com.cognitect.aws/endpoints       {:mvn/version "1.1.12.145"}
+        com.cognitect.aws/s3              {:mvn/version "814.2.1053.0"}
 
         ;; web server
         http-kit/http-kit                 {:mvn/version "2.5.3"}
-        ring/ring-core                    {:mvn/version "1.9.4"}
+        ring/ring-core                    {:mvn/version "1.9.5"}
         ring-cors/ring-cors               {:mvn/version "0.1.13"}
         compojure/compojure               {:mvn/version "1.6.2"}
 
         ;; logging
-        ch.qos.logback/logback-classic    {:mvn/version "1.2.9"}
+        ch.qos.logback/logback-classic    {:mvn/version "1.2.10"}
 
         ;; config
         environ/environ                   {:git/url   "https://github.com/cap10morgan/environ.git"
@@ -110,7 +110,7 @@
    :main-opts   ["-m" "cloverage.coverage" "-p" "src" "-s" "test" "--test-ns-regex" "^fluree\\.db\\.ledger\\.ledger-test*$" "--output" "scanning_results/coverage"]}
 
   :eastwood
-  {:extra-deps {jonase/eastwood {:mvn/version "1.1.1"}}
+  {:extra-deps {jonase/eastwood {:mvn/version "1.2.2"}}
    :main-opts ["-m" "eastwood.lint" {:source-paths ["src"] :test-paths ["test"]
                                      :config-files ["test-resources/eastwood-config.clj"]}]}
 
@@ -119,5 +119,5 @@
    :main-opts ["-m" "antq.core" "--skip=github-action"]}
 
   :clj-kondo
-  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.12.16"}}
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.01.15"}}
    :main-opts ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         ;com.fluree/db                     {:mvn/version "1.0.0-rc34"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "2c026f2e897e86c70dec5e8848dccf55d100e19a"}
+                                           :sha "bb66fbbc3d8c6ca06d8238396fe5993c74dd7705"}
         ;com.fluree/db                     {:local/root "../db"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -629,7 +629,7 @@
   [{:keys [db-after instant]} tx-map]
   (async/go
     (try
-      (when (not-empty (:deps tx-map))                      ;; transaction has dependencies listed, verify they are satisfied
+      (when (not-empty (:deps tx-map)) ; transaction has dependencies listed, verify they are satisfied
         (<? (tx-validate/tx-deps-check db-after tx-map)))
       (let [start-time (util/current-time-millis)
             tx-map*    (<? (tx-auth/add-auth-ids-permissions db-after tx-map))

--- a/src/fluree/db/ledger/txgroup/monitor.clj
+++ b/src/fluree/db/ledger/txgroup/monitor.clj
@@ -74,7 +74,6 @@
     (txproto/-new-entry-async raft command)))
 
 
-
 (defn assign-network-to-server-async
   "Uses the worker-assign feature."
   [raft server-id network]
@@ -86,6 +85,7 @@
   [raft worker-id]
   (txproto/kv-get-in raft [:_worker worker-id]))
 
+
 (defn assigned-networks-for-server
   "Returns assigned networks as a set based on server-id"
   ([raft] (assigned-networks-for-server raft (:this-server (:raft raft))))
@@ -94,6 +94,7 @@
        :networks
        keys
        (set))))
+
 
 (defn assigned-networks
   "Returns all networks that currently have assignments."
@@ -175,6 +176,7 @@
         (log/warn "Unable to assign work to servers, none are registered as active on the network.")
         (release-lock)))))
 
+
 (defn queued-tx
   "If state change is a new tx that was queued
    returns three-tuple of [network dbid txid], else nil."
@@ -194,6 +196,7 @@
         [op _ arg2] command]
     (and (= :worker-assign op)
          (= arg2 server-id))))
+
 
 (defn get-multi-txns
   [cmd cmds multiTxns]
@@ -252,6 +255,7 @@
 
 ;; holds db-queues. Creates them on the fly if needed.
 (def db-queues-atom (atom {}))
+
 
 (defn close-db-queue
   "Closes queue for db by closing channel and removing from queue atom"

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -235,8 +235,8 @@ or this server is not responsible for this ledger, will return false. Else true 
 
 (defn new-ledger-async
   "Registers new network to be created by leader."
-  [group network ledger-id cmd-id signed-cmd]
-  (let [command [:new-db network ledger-id cmd-id signed-cmd]]
+  [group network ledger-id cmd-id signed-cmd owners]
+  (let [command [:new-db network ledger-id cmd-id signed-cmd owners]]
     (-new-entry-async group command)))
 
 (defn find-all-dbs-to-initialize
@@ -303,12 +303,13 @@ or this server is not responsible for this ledger, will return false. Else true 
 (defn queue-command-async
   "Writes a new tx to the queue"
   [group network ledger-id command-id command]
-  (kv-assoc-in-async group [:cmd-queue network command-id] {:command command
-                                                            :size (count (:cmd command))
-                                                            :id command-id
-                                                            :network network
-                                                            :dbid ledger-id
-                                                            :instant (System/currentTimeMillis)}))
+  (kv-assoc-in-async group [:cmd-queue network command-id]
+                     {:command command
+                      :size (count (:cmd command))
+                      :id command-id
+                      :network network
+                      :dbid ledger-id
+                      :instant (System/currentTimeMillis)}))
 
 
 ;; Block commands


### PR DESCRIPTION
This is the ledger side of multiple root owner support for new ledgers. We already have the ability to add owners to a ledger after it's been created, but this allows specifying multiple owners at creation time.

I take advantage of this to allow the http-sig signer to own a new ledger they create, which wasn't supported previously.

db PR: https://github.com/fluree/db/pull/146

JIRA ticket: FC-1342