### PR TITLE
FC-1355 - Feature: trust http sigs for transactions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         ;com.fluree/db                     {:mvn/version "1.0.0-rc34"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "1c005351bd9a049745c329b6c09659b30d84afb6"}
+                                           :sha "572022e4afc3d9eaeec199f3c1aac629e6cee06e"}
         ;com.fluree/db                     {:local/root "../db"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,44 +1,44 @@
-{:deps {org.clojure/clojure               {:mvn/version "1.10.3"}
-        org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
-        com.fluree/alphabase              {:mvn/version "3.2.2"}
-        com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "58a4201438161a69b22679782efe79124f9a3009"}
-        com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
-        com.fluree/crypto                 {:mvn/version "0.3.7"}
+{:deps     {org.clojure/clojure            {:mvn/version "1.10.3"}
+            org.clojure/data.xml           {:mvn/version "0.2.0-alpha6"}
+            com.fluree/alphabase           {:mvn/version "3.2.2"}
+            com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
+                                            :sha     "4bbfba7cb5103f49b5d6190b4f71aca73992c446"}
+            com.fluree/raft                {:mvn/version "1.0.0-beta1"}
+            com.fluree/crypto              {:mvn/version "0.3.7"}
 
-        ;; network comm
-        net.async/async                   {:mvn/version "0.1.1"}
+            ;; network comm
+            net.async/async                {:mvn/version "0.1.1"}
 
-        ;; Lucene
-        clucie/clucie                     {:mvn/version "0.4.2"}
+            ;; Lucene
+            clucie/clucie                  {:mvn/version "0.4.2"}
 
-        ;; AWS S3 API
-        com.cognitect.aws/api             {:mvn/version "0.8.539"}
-        com.cognitect.aws/endpoints       {:mvn/version "1.1.12.145"}
-        com.cognitect.aws/s3              {:mvn/version "814.2.1053.0"}
+            ;; AWS S3 API
+            com.cognitect.aws/api          {:mvn/version "0.8.539"}
+            com.cognitect.aws/endpoints    {:mvn/version "1.1.12.153"}
+            com.cognitect.aws/s3           {:mvn/version "814.2.1053.0"}
 
-        ;; web server
-        http-kit/http-kit                 {:mvn/version "2.5.3"}
-        ring/ring-core                    {:mvn/version "1.9.5"}
-        ring-cors/ring-cors               {:mvn/version "0.1.13"}
-        compojure/compojure               {:mvn/version "1.6.2"}
+            ;; web server
+            http-kit/http-kit              {:mvn/version "2.5.3"}
+            ring/ring-core                 {:mvn/version "1.9.5"}
+            ring-cors/ring-cors            {:mvn/version "0.1.13"}
+            compojure/compojure            {:mvn/version "1.6.2"}
 
-        ;; logging
-        ch.qos.logback/logback-classic    {:mvn/version "1.2.10"}
+            ;; logging
+            ch.qos.logback/logback-classic {:mvn/version "1.2.10"}
 
-        ;; config
-        environ/environ                   {:git/url   "https://github.com/cap10morgan/environ.git"
-                                           :sha       "32682e865e8248d9df09643d6321ca4259fdbc19"
-                                           :deps/root "environ"}}
+            ;; config
+            environ/environ                {:git/url   "https://github.com/cap10morgan/environ.git"
+                                            :sha       "32682e865e8248d9df09643d6321ca4259fdbc19"
+                                            :deps/root "environ"}}
 
- :paths ["src" "resources"]
+ :paths    ["src" "resources"]
 
  :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]
 
  :aliases
- {:mvn/group-id com.fluree
+ {:mvn/group-id    com.fluree
   :mvn/artifact-id ledger
-  :mvn/version "1.0.0-beta18"
+  :mvn/version     "1.0.0-beta18"
 
   :dev
   {:extra-paths ["dev", "test"]
@@ -48,52 +48,52 @@
   {:extra-paths ["test" "test-resources"]
    :extra-deps  {com.cognitect/test-runner
                  {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                  :sha "cc75980b43011773162b485f46f939dc5fba91e4"}}
+                  :sha     "cc75980b43011773162b485f46f939dc5fba91e4"}}
    :exec-fn     cognitect.test-runner.api/test}
 
   :jar
   {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
-   :exec-fn hf.depstar/jar
-   :exec-args {:jar "target/fluree-ledger.jar"
-               :group-id :mvn/group-id
-               :artifact-id :mvn/artifact-id
-               :version :mvn/version
-               :sync-pom true}}
+   :exec-fn      hf.depstar/jar
+   :exec-args    {:jar         "target/fluree-ledger.jar"
+                  :group-id    :mvn/group-id
+                  :artifact-id :mvn/artifact-id
+                  :version     :mvn/version
+                  :sync-pom    true}}
 
   :uberjar
   {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
-   :exec-fn hf.depstar/uberjar
-   :exec-args {:jar "target/fluree-ledger.standalone.jar"
-               :aot [fluree.db.server]
-               :main-class fluree.db.server
-               :group-id :mvn/group-id
-               :artifact-id :mvn/artifact-id
-               :version :mvn/version
-               :sync-pom true}}
+   :exec-fn      hf.depstar/uberjar
+   :exec-args    {:jar         "target/fluree-ledger.standalone.jar"
+                  :aot         [fluree.db.server]
+                  :main-class  fluree.db.server
+                  :group-id    :mvn/group-id
+                  :artifact-id :mvn/artifact-id
+                  :version     :mvn/version
+                  :sync-pom    true}}
 
   :native-image
-  {:main-opts ["-m" "clj.native-image" "fluree.db.server"
-               "-H:Name=fluree-ledger" "--no-fallback"
-               "-H:+ReportExceptionStackTraces"
-               ;; IncludeResources is pretty finicky. Lots of regexes I've tried don't
-               ;; work and the logging the docs say you can turn on doesn't work.
-               ;; So I'm just including everything for now. - WSM 2021/08/20
-               "-H:IncludeResources=.*"
-               "--enable-url-protocols=http,https"
-               "--enable-all-security-services"
-               "--report-unsupported-elements-at-runtime"
-               "--initialize-at-build-time"
-               "--allow-incomplete-classpath"
-               "--install-exit-handlers"
+  {:main-opts  ["-m" "clj.native-image" "fluree.db.server"
+                "-H:Name=fluree-ledger" "--no-fallback"
+                "-H:+ReportExceptionStackTraces"
+                ;; IncludeResources is pretty finicky. Lots of regexes I've tried don't
+                ;; work and the logging the docs say you can turn on doesn't work.
+                ;; So I'm just including everything for now. - WSM 2021/08/20
+                "-H:IncludeResources=.*"
+                "--enable-url-protocols=http,https"
+                "--enable-all-security-services"
+                "--report-unsupported-elements-at-runtime"
+                "--initialize-at-build-time"
+                "--allow-incomplete-classpath"
+                "--install-exit-handlers"
 
-               ;; Most of these initialize-at-run-time classes are from https://github.com/oracle/graal/issues/2050#issuecomment-797689154
-               "--initialize-at-run-time=org.asynchttpclient.RequestBuilderBase,org.asynchttpclient.ntlm.NtlmEngine,io.netty.channel.kqueue.KQueue,io.netty.channel.kqueue.Native,io.netty.channel.kqueue.KQueueEventLoop,io.netty.channel.kqueue.KQueueEventArray,io.netty.util.internal.logging.Log4JLogger,io.netty.channel.epoll.Epoll,io.netty.channel.epoll.Native,io.netty.channel.epoll.EpollEventLoop,io.netty.channel.epoll.EpollEventArray,io.netty.channel.unix.Errors,io.netty.channel.unix.IovArray,io.netty.channel.unix.Limits,io.netty.channel.DefaultFileRegion,io.netty.handler.ssl.ReferenceCountedOpenSslContext,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.JettyNpnSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ServerEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine,org.httpkit.client.ClientSslEngineFactory$SSLHolder,abracad.avro.ClojureData$Vars,org.apache.lucene.analysis.ja.dict.UnknownDictionary$SingletonHolder,org.apache.lucene.analysis.ja.dict.TokenInfoDictionary$SingletonHolder"
+                ;; Most of these initialize-at-run-time classes are from https://github.com/oracle/graal/issues/2050#issuecomment-797689154
+                "--initialize-at-run-time=org.asynchttpclient.RequestBuilderBase,org.asynchttpclient.ntlm.NtlmEngine,io.netty.channel.kqueue.KQueue,io.netty.channel.kqueue.Native,io.netty.channel.kqueue.KQueueEventLoop,io.netty.channel.kqueue.KQueueEventArray,io.netty.util.internal.logging.Log4JLogger,io.netty.channel.epoll.Epoll,io.netty.channel.epoll.Native,io.netty.channel.epoll.EpollEventLoop,io.netty.channel.epoll.EpollEventArray,io.netty.channel.unix.Errors,io.netty.channel.unix.IovArray,io.netty.channel.unix.Limits,io.netty.channel.DefaultFileRegion,io.netty.handler.ssl.ReferenceCountedOpenSslContext,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.JettyNpnSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ServerEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine,org.httpkit.client.ClientSslEngineFactory$SSLHolder,abracad.avro.ClojureData$Vars,org.apache.lucene.analysis.ja.dict.UnknownDictionary$SingletonHolder,org.apache.lucene.analysis.ja.dict.TokenInfoDictionary$SingletonHolder"
 
-               ;; In theory this shouldn't be necessary w/ sufficient type hinting, but there's a bug in the go macro (I think)
-               ;; that causes type hinting to not always work correctly inside them and you can't access fields of Java
-               ;; types like fluree.db.flake.Flake b/c it will resort to reflection and that has to be configured under
-               ;; graalvm native-images. I haven't figured out a minimal reproduction yet though. In the meantime, this fixes it.
-               "-H:ReflectionConfigurationFiles=resources/native-image-config/reflect-config.json"]
+                ;; In theory this shouldn't be necessary w/ sufficient type hinting, but there's a bug in the go macro (I think)
+                ;; that causes type hinting to not always work correctly inside them and you can't access fields of Java
+                ;; types like fluree.db.flake.Flake b/c it will resort to reflection and that has to be configured under
+                ;; graalvm native-images. I haven't figured out a minimal reproduction yet though. In the meantime, this fixes it.
+                "-H:ReflectionConfigurationFiles=resources/native-image-config/reflect-config.json"]
    :jvm-opts   ["-Dclojure.compiler.direct-linking=true"]
    :extra-deps {clj.native-image/clj.native-image
                 {:git/url "https://github.com/taylorwood/clj.native-image.git"
@@ -109,13 +109,13 @@
 
   :eastwood
   {:extra-deps {jonase/eastwood {:mvn/version "1.2.2"}}
-   :main-opts ["-m" "eastwood.lint" {:source-paths ["src"] :test-paths ["test"]
-                                     :config-files ["test-resources/eastwood-config.clj"]}]}
+   :main-opts  ["-m" "eastwood.lint" {:source-paths ["src"] :test-paths ["test"]
+                                      :config-files ["test-resources/eastwood-config.clj"]}]}
 
   :ancient
   {:extra-deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
-   :main-opts ["-m" "antq.core" "--skip=github-action"]}
+   :main-opts  ["-m" "antq.core" "--skip=github-action"]}
 
   :clj-kondo
   {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.01.15"}}
-   :main-opts ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}}}
+   :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "--config" ".clj-kondo/config.edn"]}}}

--- a/src/fluree/db/ledger/bootstrap.clj
+++ b/src/fluree/db/ledger/bootstrap.clj
@@ -826,6 +826,10 @@
     :name "_tx/sig"
     :doc  "Signature of original JSON transaction command."
     :type "string"}
+   {:_id  ["_predicate" const/$_tx:signed]
+    :name "_tx/signed"
+    :doc  "String that _tx/sig is a signature of if it isn't _tx/tx"
+    :type "string"}
    {:_id  ["_predicate" const/$_tx:tempids]
     :name "_tx/tempids"
     :doc  "Tempid JSON map for this transaction."

--- a/src/fluree/db/ledger/consensus/update_state.clj
+++ b/src/fluree/db/ledger/consensus/update_state.clj
@@ -72,31 +72,43 @@
                              current-val)))]
     (= proposed-v (get-in new-state ks))))
 
+(defn- extract-flake-object
+  "Returns flake object (.-o flake) from block-map of the given type whose
+  subject matches (:t tx-data). Returns nil if none is found."
+  [{:keys [flakes] :as _block-map} {:keys [t] :as _tx-data} type]
+  (some #(let [^Flake flake %]
+           (when (and (= type (.-p flake))
+                      (= t (.-s flake)))
+             (.-o flake)))
+        flakes))
+
 (defn register-new-dbs
   "Register new dbs. Part of state-machine. Updates state-atom, and publishes out :new-db on event-bus"
   [txns state-atom block-map]
-  (let [init-db-status (->> txns
-                            (filter #(and (= :new-db (:type (val %)))
-                                          (= 200 (:status (val %)))))
-                            (map (fn [[_ tx-data]]
-                                   (let [t             (:t tx-data)
-                                         orig-cmd      (some #(when (and (= constants/$_tx:tx (.-p ^Flake %))
-                                                                         (= t (.-s ^Flake %)))
-                                                                (.-o ^Flake %))
-                                                             (:flakes block-map))
-                                         orig-sig      (some #(when (and (= constants/$_tx:sig (.-p ^Flake %))
-                                                                         (= t (.-s ^Flake %)))
-                                                                (.-o ^Flake %))
-                                                             (:flakes block-map))
-                                         orig-cmd-data (when orig-cmd (json/parse orig-cmd))
-                                         {:keys [db fork forkBlock]} orig-cmd-data
-                                         [network dbid] (when orig-cmd (if (sequential? db) db (str/split db #"/")))]
-                                     [network dbid (util/without-nils
-                                                     {:status    :initialize
-                                                      :command   {:cmd orig-cmd
-                                                                  :sig orig-sig}
-                                                      :fork      fork
-                                                      :forkBlock forkBlock})]))))]
+  (let [init-db-status
+        (->> txns
+             (filter #(and (= :new-db (:type (val %)))
+                           (= 200 (:status (val %)))))
+             (map (fn [[_ tx-data]]
+                    (let [efo           (partial extract-flake-object block-map
+                                                 tx-data)
+                          orig-cmd      (efo constants/$_tx:tx)
+                          orig-sig      (efo constants/$_tx:sig)
+                          orig-signed   (efo constants/$_tx:signed)
+                          orig-cmd-data (when orig-cmd (json/parse orig-cmd))
+                          {:keys [db fork forkBlock]} orig-cmd-data
+                          [network dbid] (when orig-cmd
+                                           (if (sequential? db)
+                                             db
+                                             (str/split db #"/")))]
+                      [network dbid (util/without-nils
+                                      {:status    :initialize
+                                       :command   (util/without-nils
+                                                    {:cmd    orig-cmd
+                                                     :sig    orig-sig
+                                                     :signed orig-signed})
+                                       :fork      fork
+                                       :forkBlock forkBlock})]))))]
 
     (swap! state-atom (fn [s]
                         (reduce (fn [s* [network dbid db-status]]

--- a/src/fluree/db/ledger/transact/auth.clj
+++ b/src/fluree/db/ledger/transact/auth.clj
@@ -39,7 +39,9 @@
     (let [auth-id-ch    (dbproto/-subid db ["_auth/id" auth] true)
           ;; kick off authority check in parallel (when applicable)
           authority-sid (when authority
-                          (let [authority-id (if (string? authority) ["_auth/id" authority] authority)]
+                          (let [authority-id (if (string? authority)
+                                               ["_auth/id" authority]
+                                               authority)]
                             (async/<! (dbproto/-subid db authority-id true))))
           auth-sid      (async/<! auth-id-ch)]
       (cond

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -462,7 +462,7 @@
      :txid             txid
      :tx-type          tx-type
      :tx               tx
-     :tx-string        cmd
+     :tx-string        (if (not-empty signed) (json/stringify tx) cmd)
      :signature        sig
      :signed           signed
      :nonce            nonce
@@ -589,6 +589,7 @@
     (let [{:keys [db-root auth-id authority-id txid tx t tx-type fuel permissions]} tx-state
           tx-flakes        (<? (do-transact tx-state tx))
           tx-meta-flakes   (tx-meta/tx-meta-flakes tx-state nil)
+          _                (log/trace "tx-meta flakes:" tx-meta-flakes)
           tempids-map      (tempid/result-map tx-state)
           all-flakes       (cond-> (into tx-flakes tx-meta-flakes)
                                    (not-empty tempids-map) (conj (tempid/flake tempids-map t))

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -127,8 +127,8 @@
                                  {:status 400
                                   :error  :db/invalid-tx}))))
 
-    :ref object                                             ;; will have already been conformed
-    :tag object                                             ;; will have already been conformed
+    :ref object ;; will have already been conformed
+    :tag object ;; will have already been conformed
     ;; else
     ;; TODO - type-check creates an atom to hold errors, we really just need to throw exception if error exists
     (fspec/type-check object type)))
@@ -148,7 +148,7 @@
                             (conj uniques-set ::duplicate-detected) ;; check for this special keyword in result
                             (conj uniques-set ident))))]
     (if (contains? uniques* ::duplicate-detected)
-      false                                                 ;; already registered, should throw downstream
+      false ;; already registered, should throw downstream
       true)))
 
 
@@ -225,7 +225,7 @@
   [object _id pred-info tx-state]
   (go-try
     (let [type    (pred-info :type)
-          object* (if (txfunction/tx-fn? object)            ;; should only happen for multi-cardinality objects
+          object* (if (txfunction/tx-fn? object) ;; should only happen for multi-cardinality objects
                     (<? (txfunction/execute object _id pred-info tx-state))
                     object)]
       (cond
@@ -248,7 +248,7 @@
   [object _id pred-info tx-state]
   (let [multi? (pred-info :multi)]
     (if (nil? object)
-      (async/go :delete)                                    ;; delete any existing object
+      (async/go :delete) ;; delete any existing object
       (cond-> object
               (not multi?) (resolve-object-item _id pred-info tx-state)
               multi? (#(if (sequential? %) % [%]))
@@ -319,7 +319,7 @@
                                                  <?)
                                              (<? (resolve-object obj _id* pred-info tx-state)))]
                              (recur (conj acc [pred-info obj*]) r))))
-            _id**      (or (get @tempids _id*) _id*)        ;; if a ':upsert true' value resolved to existing sid, will now be in @tempids map
+            _id**      (or (get @tempids _id*) _id*) ;; if a ':upsert true' value resolved to existing sid, will now be in @tempids map
             tempid?    (tempid/TempId? _id**)]
         (when (and delete? tempid?)
           (throw (ex-info (str "Tempid with a 'delete' action is not allowed: " _id)
@@ -328,7 +328,7 @@
           (async/>! res-chan (assoc txi* :_final-flakes (<? (tx-retract/subject _id** tx-state))))
           (loop [acc txi*
                  [[pred-info obj*] & r] pi-obj]
-            (if (nil? pred-info)                            ;; finished
+            (if (nil? pred-info) ;; finished
               (async/>! res-chan acc)
               (let [pid (pred-info :id)]
                 (cond
@@ -443,20 +443,20 @@
    {:keys [auth auth-sid authority authority-sid tx-permissions txid cmd sig
            signed nonce type] :as tx-map}]
   (let [tx-type   (keyword type)
-        tx        (case tx-type                             ;; command type is either :tx or :new-db
+        tx        (case tx-type ;; command type is either :tx or :new-db
                     :tx (:tx tx-map)
                     :new-db (tx-util/create-new-db-tx tx-map))
         db-before (cond-> db
                           tx-permissions (assoc :permissions tx-permissions))]
     {:db-before        db-before
      :db-root          db
-     :db-after         (atom nil)                           ;; store updated db here
-     :flakes           nil                                  ;; holds final list of flakes for tx once complete
+     :db-after         (atom nil) ;; store updated db here
+     :flakes           nil ;; holds final list of flakes for tx once complete
      :permissions      tx-permissions
-     :auth-id          auth                                 ;; auth id string in _auth/id
-     :auth             auth-sid                             ;; auth subject-id integer
-     :authority-id     authority                            ;; authority id string as per _auth/id (or nil if no authority)
-     :authority        authority-sid                        ;; authority subject-id integer (or nil if no authority)
+     :auth-id          auth ;; auth id string in _auth/id
+     :auth             auth-sid ;; auth subject-id integer
+     :authority-id     authority ;; authority id string as per _auth/id (or nil if no authority)
+     :authority        authority-sid ;; authority subject-id integer (or nil if no authority)
      :t                (dec (:t db))
      :instant          block-instant
      :txid             txid
@@ -480,7 +480,7 @@
      :idents           (atom {})
      ;; if a tempid resolves to existing subject via :upsert predicate, set it here. tempids don't need
      ;; to check for existing duplicate values, but if a tempid resolves via upsert, we need to check it
-     :upserts          (atom nil)                           ;; cache of resolved identities
+     :upserts          (atom nil) ;; cache of resolved identities
      ;; Unique predicate + value used in transaction kept here, to ensure the same unique is not used
      ;; multiple times within the transaction
      :uniques          (atom #{})
@@ -510,7 +510,7 @@
               ^Flake flake  (cond-> tf
                                     (tempid/TempId? s) (assoc :s (get @tempids s))
                                     (tempid/TempId? o) (assoc :o (get @tempids o)))
-              retract-flake (when (contains? @upserts s)    ;; if was an upsert resolved, could be an existing flake that needs to get retracted
+              retract-flake (when (contains? @upserts s) ;; if was an upsert resolved, could be an existing flake that needs to get retracted
                               (first (<? (tx-retract/flake (:s flake) (:p tf) (if multi? (:o flake) nil) tx-state))))
               pred-info     (fn [property] (dbproto/-p-prop db-before property (:p flake)))
               flakes*       (add-singleton-flake flakes flake retract-flake pred-info tx-state)]
@@ -611,7 +611,7 @@
 
           ;; runs all 'spec' validations
           spec-errors      (<? (tx-validate/run-queued-specs all-flakes tx-state parallelism))
-          perm-errors      (when (and (nil? spec-errors)    ;; only run permissions errors if no spec errors
+          perm-errors      (when (and (nil? spec-errors) ;; only run permissions errors if no spec errors
                                       (not (true? (:root? permissions))))
                              (<? (tx-validate/run-permissions-checks all-flakes tx-state parallelism)))]
 
@@ -620,15 +620,15 @@
                :auth         auth-id
                :authority    authority-id
                :db-before    db-root
-               :db-after     db-after                       ;; will get replaced if there is an error
-               :status       200                            ;; will get replaced if there is an error
-               :errors       nil                            ;; will get replaced if there is an error
-               :flakes       (conj all-flakes @hash-flake)  ;; will get replaced if there is an error
-               :hash         (.-o ^Flake @hash-flake)       ;; will get replaced if there is an error
-               :tempids      tempids-map                    ;; will get replaced if there is an error
-               :bytes        tx-bytes                       ;; will get replaced if there is an error
+               :db-after     db-after ;; will get replaced if there is an error
+               :status       200 ;; will get replaced if there is an error
+               :errors       nil ;; will get replaced if there is an error
+               :flakes       (conj all-flakes @hash-flake) ;; will get replaced if there is an error
+               :hash         (.-o ^Flake @hash-flake) ;; will get replaced if there is an error
+               :tempids      tempids-map ;; will get replaced if there is an error
+               :bytes        tx-bytes ;; will get replaced if there is an error
                :remove-preds (tx-schema/remove-from-post-result tx-state) ;; will get replaced if there is an error
-               :fuel         nil                            ;; additional fuel will be consumed while processing validations, fill in at end
+               :fuel         nil ;; additional fuel will be consumed while processing validations, fill in at end
                :type         tx-type}
 
               ;; replace response with error response if errors detected

--- a/src/fluree/db/ledger/transact/tx_meta.clj
+++ b/src/fluree/db/ledger/transact/tx_meta.clj
@@ -12,8 +12,8 @@
 
 (def ^:const system-predicates
   "List of _tx predicates that only Fluree can assign, any user attempt to modify these should throw."
-  #{const/$_tx:id const/$_tx:tx const/$_tx:sig const/$_tx:hash
-    const/$_tx:auth const/$_tx:authority const/$_tx:nonce
+  #{const/$_tx:id const/$_tx:tx const/$_tx:sig const/$_tx:signed
+    const/$_tx:hash const/$_tx:auth const/$_tx:authority const/$_tx:nonce
     const/$_tx:error const/$_tx:tempids
     const/$_block:number const/$_block:instant
     const/$_block:hash const/$_block:prevHash
@@ -23,13 +23,14 @@
 
 (defn tx-meta-flakes
   ([tx-state] (tx-meta-flakes tx-state nil))
-  ([{:keys [auth authority txid tx-string signature nonce t]} error-str]
+  ([{:keys [auth authority txid tx-string signature signed nonce t]} error-str]
    (let [tx-flakes [(flake/->Flake t const/$_tx:id txid t true nil)
                     (flake/->Flake t const/$_tx:tx tx-string t true nil)
                     (flake/->Flake t const/$_tx:sig signature t true nil)]]
      (cond-> tx-flakes
              auth (conj (flake/->Flake t const/$_tx:auth auth t true nil)) ;; note an error transaction may not have a valid auth
              authority (conj (flake/->Flake t const/$_tx:authority authority t true nil))
+             signed (conj (flake/->Flake t const/$_tx:signed signed t true nil))
              nonce (conj (flake/->Flake t const/$_tx:nonce nonce t true nil))
              error-str (conj (flake/->Flake t const/$_tx:error error-str t true nil))))))
 

--- a/test/fluree/db/ledger/api/closed_test.clj
+++ b/test/fluree/db/ledger/api/closed_test.clj
@@ -1,0 +1,134 @@
+(ns fluree.db.ledger.api.closed-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.test-helpers :as test]
+            [fluree.db.api.auth :as fdb-auth]
+            [fluree.db.query.http-signatures :as http-sig]
+            [fluree.db.util.json :as json]
+            [org.httpkit.client :as http]
+            [fluree.db.api :as fdb]
+            [clojure.core.async :as async]
+            [fluree.crypto :as crypto])
+  (:import (java.util UUID)))
+
+(use-fixtures :once (partial test/test-system
+                             {:fdb-api-open false}))
+
+
+(def endpoint (str "http://localhost:" @test/port "/fdb/"))
+
+(defn transact-and-query-user?
+  "Returns a vector of [success? txn-response query-response]. success? will be
+  true iff the given private-key can transact and query back out a _user in the
+  given ledger. For verifying permissions / ownership."
+  [ledger private-key]
+  (let [base-req          {:headers {"content-type" "application/json"}}
+        txn-endpoint (str endpoint ledger "/transact")
+        username          (str "tester-" (UUID/randomUUID))
+        txn-req           (assoc base-req
+                            :body (json/stringify
+                                    [{:_id "_user", :username username}]))
+        signed-txn-req    (http-sig/sign-request :post txn-endpoint txn-req
+                                                 private-key)
+
+        {txn-status :status :as txn-response}
+        @(http/post txn-endpoint signed-txn-req)
+
+        query-endpoint    (str endpoint ledger "/query")
+        users-query       (-> {:select ["*"], :from "_user"}
+                              json/stringify
+                              (as-> $q
+                                    (assoc base-req :body $q)
+                                    (http-sig/sign-request :post
+                                                           query-endpoint $q
+                                                           private-key)))
+
+        {query-status :status, query-body :body :as query-response}
+        @(http/post query-endpoint users-query)]
+    [(and (= 200 txn-status query-status)
+          (= username (-> query-body json/parse first :_user/username)))
+     txn-response query-response]))
+
+
+(deftest ^:wes new-db-test
+  (testing "new db (ledger actually) is owned by request signer"
+    (let [{:keys [private id]} (fdb-auth/new-private-key)
+          new-db-endpoint   (str endpoint "new-db")
+          base-req          {:headers {"content-type" "application/json"}}
+          ledger            (str "test/ledger-" (UUID/randomUUID))
+          create-req        (assoc base-req
+                              :body (json/stringify {:db/id ledger}))
+          signed-create-req (http-sig/sign-request :post new-db-endpoint
+                                                   create-req private)
+          {create-status :status} @(http/post new-db-endpoint
+                                              signed-create-req)
+          _                 (fdb/wait-for-ledger-ready
+                              (:conn test/system) ledger)
+          query-endpoint    (str endpoint ledger "/query")
+          owners-query      (-> {:select ["*"], :from "_auth"}
+                                json/stringify
+                                (as-> $q
+                                      (assoc base-req :body $q)
+                                      (http-sig/sign-request :post
+                                                             query-endpoint $q
+                                                             private)))
+
+          {owners-query-status :status, owners-query-body :body}
+          @(http/post query-endpoint owners-query)]
+      (is (every? #(= 200 %) [create-status owners-query-status]))
+      (is (= id (-> owners-query-body json/parse first :_auth/id)))))
+
+  (testing "request signer can transact against new db (actually ledger) they create"
+    (let [{:keys [private]} (fdb-auth/new-private-key)
+          new-db-endpoint   (str endpoint "new-db")
+          base-req          {:headers {"content-type" "application/json"}}
+          ledger            (str "test/ledger-" (UUID/randomUUID))
+          create-req        (assoc base-req
+                              :body (json/stringify {:db/id ledger}))
+          signed-create-req (http-sig/sign-request :post new-db-endpoint
+                                                   create-req private)
+          {create-status :status} @(http/post new-db-endpoint
+                                              signed-create-req)
+          _                 (fdb/wait-for-ledger-ready
+                              (:conn test/system) ledger)]
+      (is (= 200 create-status))
+      (let [[success? txn-response query-response]
+            (transact-and-query-user? ledger private)]
+        (is success? (str "Transaction response: " (pr-str txn-response)
+                          "Query response: " (pr-str query-response))))))
+
+  (testing "new db (ledger actually) is owned by owners specified in request"
+    (let [{private-1 :private, auth-id-1 :id} (fdb-auth/new-private-key)
+          {private-2 :private, auth-id-2 :id} (fdb-auth/new-private-key)
+          {private-3 :private, auth-id-3 :id} (fdb-auth/new-private-key)
+          new-db-endpoint   (str endpoint "new-db")
+          base-req          {:headers {"content-type" "application/json"}}
+          ledger            (str "test/ledger-" (UUID/randomUUID))
+          create-req        (assoc base-req
+                              :body (json/stringify
+                                      {:db/id  ledger
+                                       :owners [auth-id-2 auth-id-3]}))
+          signed-create-req (http-sig/sign-request :post new-db-endpoint
+                                                   create-req private-1)
+          {create-status :status} @(http/post new-db-endpoint
+                                              signed-create-req)
+          _                 (fdb/wait-for-ledger-ready
+                              (:conn test/system) ledger)
+          query-endpoint    (str endpoint ledger "/query")
+          owners-query      (-> {:select ["*"], :from "_auth"}
+                                json/stringify
+                                (as-> $q
+                                      (assoc base-req :body $q)
+                                      (http-sig/sign-request :post
+                                                             query-endpoint $q
+                                                             private-2)))
+
+          {owners-query-status :status, owners-query-body :body}
+          @(http/post query-endpoint owners-query)]
+      (is (every? #(= 200 %) [create-status owners-query-status]))
+      (is (= #{auth-id-1 auth-id-2 auth-id-3}
+             (->> owners-query-body
+                  json/parse
+                  (map :_auth/id)
+                  set)))
+      (is (every? #(transact-and-query-user? ledger %)
+                  [private-1 private-2 private-3])))))

--- a/test/fluree/db/ledger/docs/identity/auth.clj
+++ b/test/fluree/db/ledger/docs/identity/auth.clj
@@ -3,6 +3,7 @@
             [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
+            [fluree.db.api.auth :as fdb-auth]
             [clojure.core.async :as async]
             [clojure.string :as str]))
 
@@ -10,7 +11,7 @@
 
 ; Add new auth record with permissions and test
 (deftest viewPersonNoHandle
-  (let [{:keys [private public id]} (fdb/new-private-key)
+  (let [{:keys [private public id]} (fdb-auth/new-private-key)
         addAuth         [{:_id   "_auth"
                           :id    id
                           :roles ["_role$standardUser"]}
@@ -60,7 +61,7 @@
 
 (deftest createAuthority
   ;; TODO - sometimes fails, does this have to do with padding in crypto?
-  (let [{:keys [private public id]} (fdb/new-private-key)
+  (let [{:keys [private public id]} (fdb-auth/new-private-key)
         opts          {:timeout 240000}
         addAuth       [{:_id "_auth$authority"
                         :id  id}

--- a/test/fluree/db/test_helpers.clj
+++ b/test/fluree/db/test_helpers.clj
@@ -9,7 +9,7 @@
             [clojure.edn :as edn]
             [fluree.db.util.json :as json]
             [org.httpkit.client :as http]
-            [fluree.db.query.http-signatures :as http-sig])
+            [fluree.db.api.auth :as fdb-auth])
   (:import (java.net ServerSocket)
            (java.util UUID)))
 
@@ -204,6 +204,46 @@
   transact-data
   (partial transact-resource :data))
 
+
+(defn create-auths
+  "Creates 3 auths in the given ledger: root, all persons, all persons no
+  handles. Returns of vector of [key-maps create-txn-result]."
+  ([ledger] (create-auths ledger (:conn system)))
+  ([ledger conn]
+   (let [keys     (vec (repeatedly 3 fdb-auth/new-private-key))
+         add-auth [{:_id   "_auth"
+                    :id    (get-in keys [0 :id])
+                    :roles [["_role/id" "root"]]}
+                   {:_id   "_auth"
+                    :id    (get-in keys [1 :id])
+                    :roles ["_role$allPersons"]}
+                   {:_id   "_auth"
+                    :id    (get-in keys [2 :id])
+                    :roles ["_role$noHandles"]}
+                   {:_id   "_role$allPersons"
+                    :id    "allPersons"
+                    :rules ["_rule$allPersons"]}
+                   {:_id   "_role$noHandles"
+                    :id    "noHandles"
+                    :rules ["_rule$allPersons" "_rule$noHandles"]}
+                   {:_id               "_rule$allPersons"
+                    :id                "role$allPersons"
+                    :collection        "person"
+                    :collectionDefault true
+                    :fns               [["_fn/name" "true"]]
+                    :ops               ["all"]}
+                   {:_id        "_rule$noHandles"
+                    :id         "noHandles"
+                    :collection "person"
+                    :predicates ["person/handle"]
+                    :fns        [["_fn/name" "false"]]
+                    :ops        ["all"]}]]
+     [keys (->> add-auth
+                (fdb/transact-async conn ledger)
+                <!!)])))
+
+
+;; ======================== DEPRECATED ===============================
 
 (defn ^:deprecated test-system-deprecated
   "This fixture is deprecated. As tests are converted to the more idiomatic


### PR DESCRIPTION
ledger counterpart to https://github.com/fluree/db/pull/147

JIRA ticket: FC-1355

Builds on #129 so review that one first :)

I implemented this by adding a new `:signed` flake type that holds the string we signed (to get the `:sig` flake) when that string is something other than the command in the `:tx` flake (which it previously always was before this PR).