### PR TITLE
Fix/txn error not propagated

### DIFF
--- a/src/fluree/db/ledger/transact/validation.clj
+++ b/src/fluree/db/ledger/transact/validation.clj
@@ -566,8 +566,10 @@
               result-ch (async/chan parallelism)
               af        (fn [f res-chan]
                           (async/go
-                            (let [fn-result (as-> (f tx-state*) res
-                                                  (if (channel? res) (async/<! res) res))]
+                            (let [fn-result (try
+                                              (as-> (f tx-state*) res
+                                                    (if (channel? res) (async/<! res) res))
+                                              (catch Exception e e))]
                               (when-not (nil? fn-result)
                                 (async/put! res-chan fn-result))
                               (async/close! res-chan))))]


### PR DESCRIPTION
Errors from predicate specs (e.g., unique) were being swallowed and not propagated up to the API layer.  The results 

1) a timeout was returned through the API
2) the transaction was being re-queued (multiple times) for processing. This blocked newer transactions from being processed.  

Since go/try inside a function didn't fix the issue; added a try/block to catch the ExceptionInfo and return it for processing.

Also added a unit test for this scenario.

