### PR TITLE
FC-1364: Orphaned Index Nodes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "5b2cd336b64ca375cea6ca5459ee353642071a5a"}
+                                           :sha "96fc34765f14ea301552dccc55e09efc2f7b0a49"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,8 @@
 {:deps {org.clojure/clojure               {:mvn/version "1.10.3"}
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
-        ;com.fluree/db                     {:mvn/version "1.0.0-rc34"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
                                            :sha "2c026f2e897e86c70dec5e8848dccf55d100e19a"}
-        ;com.fluree/db                     {:local/root "../db"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "181fbb34ad1e84a044e55d2aa5eb3548f67942fc"}
+                                           :sha "5b2cd336b64ca375cea6ca5459ee353642071a5a"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "db8aff760deee33dea8e7f42a1aea59dc3cf83d0"}
+                                           :sha "181fbb34ad1e84a044e55d2aa5eb3548f67942fc"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "00fb22b70d6ea7f10d1cedd32aaa692dc2293fef"}
+                                           :sha "db8aff760deee33dea8e7f42a1aea59dc3cf83d0"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
         com.fluree/db                     {:git/url "https://github.com/fluree/db.git"
-                                           :sha "1c005351bd9a049745c329b6c09659b30d84afb6"}
+                                           :sha "00fb22b70d6ea7f10d1cedd32aaa692dc2293fef"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/dev/replay_txns.clj
+++ b/dev/replay_txns.clj
@@ -12,14 +12,14 @@
 (defn- block-flakes
   "Returns block flakes for specified block"
   [conn network dbid block]
-  (-> (storage/block conn network dbid block)
+  (-> (storage/read-block conn network dbid block)
       (async/<!!)
       :flakes))
 
 (defn- nearest-index-point
   "Given a block, finds closest index point prior to or equal to provided block."
   [conn db-ident block]
-  (let [db-info       @(fdb/ledger-status conn db-ident)
+  (let [db-info       @(fdb/ledger-info conn db-ident)
         index-points  (-> db-info :indexes keys sort reverse)
         closest-point (->> index-points
                            (filter #(<= % block))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -475,31 +475,6 @@
                                           :name "temp5"}]))
 
 
-(comment
-  (let [{:keys [conn]} system
-        network "test-chat"
-        dbid "v4"
-        {:keys [blank-db]} (session/session conn [network dbid])]
-    (async/go-loop [block 2
-                    db    (async/<! (reindex/write-genesis-block blank-db))]
-      (if-let [{:keys [flakes]} (async/<! (storage/read-block conn network dbid block))]
-        (let [db*          (async/<! (dbproto/-with db block flakes {:reindex? true}))
-              novelty-size (get-in db* [:novelty :size])]
-          (log/info (str "  -> Reindex dbid: " dbid
-                         " block: " block
-                         " containing " (count flakes)
-                         " flakes. Novelty size: " novelty-size "."))
-          (let [db**  (async/<! (indexing/refresh db*))
-                group (-> db** :conn :group)]
-            (txproto/write-index-point-async group db**)
-            (recur (inc block) db**)))
-        db))))
-
-
-
-
-
-
 
 (comment)
 

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -87,17 +87,6 @@
               (resolve-if-novel conn child t novelty remove-preds error-ch)))
        (async/map vector)))
 
-(defn descendant?
-  [{:keys [rhs leftmost?], cmp :comparator, first-flake :first, :as branch}
-   {node-first :first, node-rhs :rhs, :as node}]
-  (if-not (index/branch? branch)
-    false
-    (and (or leftmost?
-             (not (pos? (cmp first-flake node-first))))
-         (or (nil? rhs)
-             (and (not (nil? node-rhs))
-                  (not (pos? (cmp node-rhs rhs))))))))
-
 (defn filter-predicates
   [preds & flake-sets]
   (if (seq preds)
@@ -176,9 +165,10 @@
          (map (fn [kids]
                 (update-branch branch idx kids)))
          (fn [[maybe-leftmost & not-leftmost]]
-           (into [maybe-leftmost] (map (fn [non-left-node]
-                                         (assoc non-left-node
-                                                :leftmost? false)))
+           (into [maybe-leftmost]
+                 (map (fn [non-left-node]
+                        (assoc non-left-node
+                               :leftmost? false)))
                  not-leftmost)))))
 
 (defn integrate-novelty
@@ -216,7 +206,8 @@
                   stack*      @stack
                   result*     result]
              (let [child (peek stack*)]
-               (if (and child (descendant? node child)) ; all of a resolved
+               (if (and child
+                        (index/descendant? node child)) ; all of a resolved
                                                         ; branch's children
                                                         ; should be at the top
                                                         ; of the stack

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -193,7 +193,7 @@
     (let [stack (volatile! [])]
       (fn
         ;; Initialization: do nothing but initialize the nested transformer by
-        ;; calling it's initializing fn.
+        ;; calling its initializing fn.
         ([]
          (xf))
 

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -200,7 +200,8 @@
              (if (or (seq new-flakes) (seq to-remove))
                (let [new-leaves (update-leaf node idx new-flakes to-remove)]
                  (vswap! stack into new-leaves))
-               (vswap! stack conj node)))
+               (vswap! stack conj node))
+             result)
 
            (loop [child-nodes []
                   stack*      @stack
@@ -224,7 +225,8 @@
                             result**))
                    (let [branch (cond-> node
                                   (seq child-nodes) (update-branch idx child-nodes))]
-                     (vswap! stack conj branch))))))))
+                     (vswap! stack conj branch)
+                     result*)))))))
 
         ;; Completion: Flush the stack iterating each remaining node with the
         ;; nested transformer before calling the nested transformer's completion

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -174,6 +174,14 @@
              :rhs rhs))
     branch))
 
+(defn update-sibling-leftmost
+  [[maybe-leftmost & not-leftmost]]
+  (into [maybe-leftmost]
+        (map (fn [non-left-node]
+               (assoc non-left-node
+                      :leftmost? false)))
+        not-leftmost))
+
 (defn rebalance-children
   [branch idx t child-nodes]
   (let [target-count (/ *overflow-children* 2)]
@@ -181,12 +189,7 @@
          (partition-all target-count)
          (map (fn [kids]
                 (update-branch branch idx t kids)))
-         (fn [[maybe-leftmost & not-leftmost]]
-           (into [maybe-leftmost]
-                 (map (fn [non-left-node]
-                        (assoc non-left-node
-                               :leftmost? false)))
-                 not-leftmost)))))
+         update-sibling-leftmost)))
 
 (defn integrate-novelty
   "Returns a transducer that transforms a stream of index nodes in depth first

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -216,7 +216,10 @@
                   stack*      @stack
                   result*     result]
              (let [child (peek stack*)]
-               (if (and child (descendant? node child))
+               (if (and child (descendant? node child)) ; all of a resolved
+                                                        ; branch's children
+                                                        ; should be at the top
+                                                        ; of the stack
                  (recur (conj child-nodes child)
                         (vswap! stack pop)
                         (xf result* child))

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -152,7 +152,7 @@
   (->> nodes
        (map :t)
        (some (fn [node-t]
-               (> node-t t)))
+               (> t node-t))) ; t gets smaller as it moves forward!
        boolean))
 
 (defn update-branch

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -275,15 +275,15 @@
       children)))
 
 (defn descendant?
-  [{:keys [rhs], first-flake :first, :as branch} node]
+  [{:keys [rhs leftmost?], cmp :comparator, first-flake :first, :as branch}
+   {node-first :first, node-rhs :rhs, :as node}]
   (if-not (index/branch? branch)
     false
-    (let [cmp (:comparator branch)
-          {node-first :first, node-rhs :rhs} node]
-      (and (not (pos? (cmp first-flake node-first)))
-           (or (nil? rhs)
-               (and (not (nil? node-rhs))
-                    (not (pos? (cmp node-rhs rhs)))))))))
+    (and (or leftmost?
+             (not (pos? (cmp first-flake node-first))))
+         (or (nil? rhs)
+             (and (not (nil? node-rhs))
+                  (not (pos? (cmp node-rhs rhs))))))))
 
 (defn pop-descendants
   "Pops all the descendants of `branch` off of the top of the stack `in-stack`"

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -269,7 +269,8 @@
 (defn write-node
   "Writes `node` to storage, and puts any errors onto the `error-ch`"
   [conn idx {:keys [id network dbid] :as node} error-ch]
-  (let [display-node (select-keys node [:id :network :dbid])]
+  (let [node         (dissoc node ::old-id)
+        display-node (select-keys node [:id :network :dbid])]
     (go
       (try*
        (if (index/leaf? node)

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -77,7 +77,14 @@
     (-> node
         (index/at-t t novelty)
         (update :flakes except-preds remove-preds))
-    node))
+    (let [cmp         (:comparator node)
+          novel-first (-> node
+                          (index/novelty-subrange t novelty)
+                          first)]
+      (update node :first (fn [f]
+                            (if (neg? (cmp f novel-first))
+                              f
+                              novel-first))))))
 
 (defn resolve-if-novel
   "Resolves data associated with `node` from storage configured in the connection

--- a/src/fluree/db/ledger/reindex.clj
+++ b/src/fluree/db/ledger/reindex.clj
@@ -188,9 +188,12 @@
              (let [{:keys [flakes]} block-data
                    db*          (<? (dbproto/-with db block flakes {:reindex? true}))
                    novelty-size (get-in db* [:novelty :size])]
-               (log/info (str "  -> Reindex dbid: " dbid " block: " block " containing " (count flakes) " flakes. Novelty size: " novelty-size "."))
+               (log/info (str "  -> Reindex dbid: " dbid
+                              " block: " block
+                              " containing " (count flakes)
+                              " flakes. Novelty size: " novelty-size "."))
                (if (>= novelty-size max-novelty)
-                 (let [db**  (async/<!! (indexing/refresh db*))
+                 (let [db**  (<? (indexing/refresh db*))
                        group (-> db** :conn :group)]
                    (txproto/write-index-point-async group db**)
                    (recur (inc block) db**))

--- a/test/fluree/db/ledger/indexing_test.clj
+++ b/test/fluree/db/ledger/indexing_test.clj
@@ -16,47 +16,66 @@
   (reverse (range newest oldest)))
 
 (deftest integrate-novelty-test
-  (testing "integrate-novelty"
-    (let [network "network"
-          lgr-id  "ledger"
+  (testing "integrate-novelty with existing index tree"
+    (let [network       "network"
+          lgr-id        "ledger"
 
           ;; The specific index and comparator shouldn't matter. We just have to
           ;; be consistent with the choice.
-          idx     :spot
-          cmp     (get index/default-comparators idx)]
-      (testing "with existing index tree"
-        (let [first-tx       -5
-              last-tx        -10
-              old-txns       (tx-range first-tx last-tx)
+          idx           :spot
+          cmp           (get index/default-comparators idx)
+          first-tx      -5
+          last-tx       -10
+          old-txns      (tx-range first-tx last-tx)
 
-              first-subj     10
-              last-subj      15
-              subjs          (range first-subj last-subj)
+          first-subj    10
+          last-subj     15
+          subjs         (range first-subj last-subj)
 
-              first-pred     100
-              last-pred      105
-              old-preds      (range first-pred last-pred)
+          first-pred    100
+          last-pred     105
+          old-preds     (range first-pred last-pred)
 
-              first-obj      1000
-              last-obj       1005
-              old-objs       (range first-obj last-obj)
+          first-obj     1000
+          last-obj      1005
+          old-objs      (range first-obj last-obj)
 
-              old-flakes     (map flake/->Flake
-                                  subjs old-preds old-objs
-                                  old-txns (repeat true) (repeat {}))
-              old-leaf-id    (storage/random-leaf-id network lgr-id idx)
-              old-leaf       (-> (index/new-leaf network lgr-id cmp old-flakes)
-                                 (assoc :id old-leaf-id))
+          old-flakes    (map flake/->Flake
+                             subjs old-preds old-objs
+                             old-txns (repeat true) (repeat {}))
 
-              old-branch-id  (storage/random-branch-id network lgr-id idx)
-              old-branch     (-> (index/new-branch network lgr-id cmp [old-leaf])
-                                 (assoc :id old-branch-id))
+          old-leaf-id   (storage/random-leaf-id network lgr-id idx)
+          old-leaf      (-> (index/new-leaf network lgr-id cmp old-flakes)
+                            (assoc :id old-leaf-id))
 
-              old-index      [old-leaf old-branch]]
-          (testing "with empty novelty"
-            (let [new-tx             (inc-tx last-tx)
-                  novelty            (flake/sorted-set-by cmp)
-                  index-xf           (indexing/integrate-novelty idx new-tx novelty #{})
-                  subject-under-test (into [] index-xf old-index)]
-              (is (= subject-under-test old-index)
-                  "doesn't change the index"))))))))
+          old-branch-id (storage/random-branch-id network lgr-id idx)
+          old-branch    (-> (index/new-branch network lgr-id cmp [old-leaf])
+                            (assoc :id old-branch-id))
+
+          old-index     [old-leaf old-branch]]
+
+      (testing "with empty novelty"
+        (let [new-tx             (inc-tx last-tx)
+              novelty            (flake/sorted-set-by cmp)
+              index-xf           (indexing/integrate-novelty idx new-tx novelty #{})
+              subject-under-test (into [] index-xf old-index)]
+          (is (= subject-under-test old-index)
+              "doesn't change the index")))
+
+      (testing "adding lower sorted flakes"
+        (let [new-tx             (inc-tx last-tx)
+              lower-subj         (inc last-subj)
+
+              novelty-flakes     (map flake/->Flake
+                                      (repeat lower-subj) old-preds old-objs
+                                      (repeat new-tx) (repeat true) (repeat {}))
+              novelty            (apply flake/sorted-set-by cmp novelty-flakes)
+              lowest-novelty     (first novelty)
+
+              index-xf           (indexing/integrate-novelty idx new-tx novelty #{})
+              subject-under-test (into [] index-xf old-index)]
+          (is (->> subject-under-test
+                   (filter :leftmost?)
+                   (map :first)
+                   (every? #{lowest-novelty}))
+              "sets the first novelty item as first flake for every leftmost node"))))))

--- a/test/fluree/db/ledger/indexing_test.clj
+++ b/test/fluree/db/ledger/indexing_test.clj
@@ -108,8 +108,13 @@
 
               index-xf           (indexing/integrate-novelty idx new-tx novelty #{})
               subject-under-test (into [] index-xf old-index)]
+
           (is (->> subject-under-test
                    (filter :leftmost?)
                    (map :first)
                    (every? #{lowest-novelty}))
-              "sets the first novelty item as first flake for every leftmost node"))))))
+              "sets the first novelty item as first flake for every leftmost node")
+
+          (is (contains? (->> subject-under-test last :children vals set)
+                         (first subject-under-test))
+              "preserves the node ancestry"))))))

--- a/test/fluree/db/ledger/indexing_test.clj
+++ b/test/fluree/db/ledger/indexing_test.clj
@@ -1,0 +1,62 @@
+(ns fluree.db.ledger.indexing-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.flake :as flake]
+            [fluree.db.index :as index]
+            [fluree.db.storage.core :as storage]
+            [fluree.db.ledger.indexing :as indexing]))
+
+(defn inc-tx
+  [tx]
+  (dec tx))
+
+(defn tx-range
+  "Special range function for transaction values because transaction values are
+  negative so new transactions are smaller than older ones"
+  [oldest newest]
+  (reverse (range newest oldest)))
+
+(deftest integrate-novelty-test
+  (testing "integrate-novelty"
+    (let [network "network"
+          lgr-id  "ledger"
+
+          ;; The specific index and comparator shouldn't matter. We just have to
+          ;; be consistent with the choice.
+          idx     :spot
+          cmp     (get index/default-comparators idx)]
+      (testing "with existing index tree"
+        (let [first-tx       -5
+              last-tx        -10
+              old-txns       (tx-range first-tx last-tx)
+
+              first-subj     10
+              last-subj      15
+              subjs          (range first-subj last-subj)
+
+              first-pred     100
+              last-pred      105
+              old-preds      (range first-pred last-pred)
+
+              first-obj      1000
+              last-obj       1005
+              old-objs       (range first-obj last-obj)
+
+              old-flakes     (map flake/->Flake
+                                  subjs old-preds old-objs
+                                  old-txns (repeat true) (repeat {}))
+              old-leaf-id    (storage/random-leaf-id network lgr-id idx)
+              old-leaf       (-> (index/new-leaf network lgr-id cmp old-flakes)
+                                 (assoc :id old-leaf-id))
+
+              old-branch-id  (storage/random-branch-id network lgr-id idx)
+              old-branch     (-> (index/new-branch network lgr-id cmp [old-leaf])
+                                 (assoc :id old-branch-id))
+
+              old-index      [old-leaf old-branch]]
+          (testing "with empty novelty"
+            (let [new-tx             (inc-tx last-tx)
+                  novelty            (flake/sorted-set-by cmp)
+                  index-xf           (indexing/integrate-novelty idx new-tx novelty #{})
+                  subject-under-test (into [] index-xf old-index)]
+              (is (= subject-under-test old-index)
+                  "doesn't change the index"))))))))


### PR DESCRIPTION
This patch refactors the indexing process to separate reading/writing indexes to/from storage from the actual algorithm of integrating novelty flakes into those nodes and rebalancing them as necessary. 

The indexing algorithm itself is now specified as a [transducer](https://github.com/fluree/ledger/pull/133/files#diff-ac9a23749e407a3ebb3af5cea52bddad5af09dea3256c5fe1c5dc973448e9471R191-R250) that transform a stream of index nodes in depth-first order into another stream of nodes, in the same order, with the novelty incorporated and nodes rebalanced as necessary. This transducer doesn't care about where the nodes came from or where they are going, so it works equally on a core.async channel, lazy sequence, or vector. This makes it possible to write tests for the indexing process isolated from any storage or i/o concerns. 

I made this refactor because of the bug described in [FC-1364](https://fluree.atlassian.net/browse/FC-1364). After reindexing databases, some nodes could end up missing from the result because the indexing process failed to consider whether or not a branch/leaf pair were both `leftmost?` when deciding if the leaf was a descendant of the branch. The fix for this bug was simple once it was identified, but that it appeared at all showed the folly of punting on indexing tests during the tspo refactor.

There could definitely be more tests here, but the framework is now in place that will allow us to add them over time.