### PR TITLE
FC-1367 - Feature: http request id header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM clojure:openjdk-11-tools-deps-1.10.3.1058-slim-bullseye AS builder
+FROM --platform=$BUILDPLATFORM clojure:openjdk-11-tools-deps-1.10.3.1075-slim-bullseye AS builder
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl
 


### PR DESCRIPTION
If there is a request header `X-Fdb-Request-Id`, save its value and return it in the response in the HTTP API. For Nexus request tracing.

Implements FC-1367