### PR TITLE
preserve id under the old-id for nodes updated during indexing

### DIFF
--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -210,6 +210,10 @@
              (xf result*))))))))
 
 (defn preserve-id
+  "Stores the original id of a node under the `::old-id` key if the `node` was
+  resolved, leaving unresolved nodes unchanged. Useful for keeping track of the
+  original id for modified nodes during the indexing process for garbage
+  collection purposes"
   [{:keys [id] :as node}]
   (cond-> node
     (index/resolved? node) (assoc ::old-id id)))

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -209,6 +209,11 @@
                     (unreduced (xf result* node)))
              (xf result*))))))))
 
+(defn preserve-id
+  [{:keys [id] :as node}]
+  (cond-> node
+    (index/resolved? node) (assoc ::old-id id)))
+
 (defn write-node
   "Writes `node` to storage, and puts any errors onto the `error-ch`"
   [conn idx {:keys [id network dbid] :as node} error-ch]
@@ -244,7 +249,8 @@
 
 (defn refresh-index
   [conn network dbid error-ch {::keys [idx t novelty remove-preds root]}]
-  (let [refresh-xf (integrate-novelty idx t novelty remove-preds)
+  (let [refresh-xf (comp (map preserve-id)
+                         (integrate-novelty idx t novelty remove-preds))
         novel?     (fn [node]
                      (or (seq remove-preds)
                          (seq (index/novelty-subrange node t novelty))))]


### PR DESCRIPTION
This fixes a bug where new ledgers can't be created (and old ledgers can't be indexed) I introduced by trying to DRY up tree walking code without accounting for downstream code that relies on the previous id from index nodes to be preserved under the `old-id` key. The indexing process itself succeeds, but no garbage could be serialized because the garbage keys were not preserved. 

This patch adds back the old-id key for updated nodes, allowing them to be serialized. 