### PR TITLE
Test file storage ledger create & interaction & fix race condition in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,12 @@ target/fluree-ledger.jar: resources/adminUI $(SOURCES) $(RESOURCES)
 
 jar: target/fluree-ledger.jar
 
+unit-test:
+	clojure -X:test :excludes '[:integration]'
+
+integration-test:
+	clojure -X:test :includes '[:integration]'
+
 test:
 	clojure -X:test
 

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -1,7 +1,8 @@
 (ns fluree.db.ledger.txgroup.txgroup-proto
   (:require [clojure.string :as str]
             [fluree.db.util.core :as util]
-            [clojure.core.async :as async]))
+            [clojure.core.async :as async]
+            [fluree.db.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
@@ -199,6 +200,9 @@ or this server is not responsible for this ledger, will return false. Else true 
 (defn ledger-info
   "Returns all info we have on given ledger."
   [group network ledger-id]
+  (log/debug "Getting ledger-info at key-path"
+             [:networks network :dbs ledger-id]
+             "from:" (-local-state group))
   (kv-get-in group [:networks network :dbs ledger-id]))
 
 (defn ledgers-info-map

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -8,7 +8,7 @@
 <configuration scan="true">
 
     <!-- Console output -->
-    <appender name="STDOUT-TEST" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
         <encoder>
             <!-- ensure logs including exceptions are a single line -->
@@ -17,9 +17,10 @@
     </appender>
 
     <root level="OFF">
-        <appender-ref ref="STDOUT-TEST"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 
     <logger name="fluree.db.test-helpers" level="ERROR"/>
+    <!-- <logger name="fluree.db" level="DEBUG"/> -->
 
 </configuration>

--- a/test/fluree/db/ledger/integration/file_storage_test.clj
+++ b/test/fluree/db/ledger/integration/file_storage_test.clj
@@ -3,20 +3,32 @@
   with file storage to make sure that's not broken."
   (:require [clojure.test :refer :all]
             [fluree.db.test-helpers :as test]
-            [fluree.db.api :as api])
+            [fluree.db.api :as api]
+            [clojure.java.io :as io]
+            [clojure.core.async :refer [<!!]])
   (:import (org.apache.commons.io FileUtils)))
 
 (use-fixtures :once (fn [t]
                       (let [data-dir (test/create-temp-dir)]
                         (test/test-system
-                          {:fdb-storage-type      "file"
-                           :fdb-consensus-type    "raft"
-                           :fdb-storage-file-root (.getPath data-dir)}
+                          {:fdb-storage-type        "file"
+                           :fdb-consensus-type      "raft"
+                           :fdb-storage-file-root   (.getPath data-dir)
+                           :fdb-group-log-directory (-> data-dir
+                                                        (io/file "group")
+                                                        .getPath)}
                           t)
+                        (Thread/sleep 100) ; don't race system shutdown to delete files
                         (FileUtils/deleteDirectory data-dir))))
 
 (deftest ^:integration create-new-ledger-test
   (testing "new ledger initializes, accepts transactions, & responds to queries"
-    (let [ledger (test/rand-ledger "file-storage/test")]
-      (is (= 200 (:status (api/transact (:conn test/system) ledger
-                                        [{:_id "_user", "_user/username" "tester"}])))))))
+    (let [ledger (test/rand-ledger "file-storage/test")
+          txn-result (<!! (api/transact-async
+                            (:conn test/system) ledger
+                            [{:_id "_user", "_user/username" "tester"}]))]
+      (is (= 200 (:status txn-result)))
+      (let [db (api/db (:conn test/system) ledger)
+            query-result (<!! (api/query-async db {:selectOne [:_user/username]
+                                                   :from "_user"}))]
+        (is (= "tester" (:_user/username query-result)))))))

--- a/test/fluree/db/ledger/integration/file_storage_test.clj
+++ b/test/fluree/db/ledger/integration/file_storage_test.clj
@@ -1,0 +1,22 @@
+(ns fluree.db.ledger.integration.file-storage-test
+  "Most tests use in-memory ledgers, but these test a few ledger operations
+  with file storage to make sure that's not broken."
+  (:require [clojure.test :refer :all]
+            [fluree.db.test-helpers :as test]
+            [fluree.db.api :as api])
+  (:import (org.apache.commons.io FileUtils)))
+
+(use-fixtures :once (fn [t]
+                      (let [data-dir (test/create-temp-dir)]
+                        (test/test-system
+                          {:fdb-storage-type      "file"
+                           :fdb-consensus-type    "raft"
+                           :fdb-storage-file-root (.getPath data-dir)}
+                          t)
+                        (FileUtils/deleteDirectory data-dir))))
+
+(deftest ^:integration create-new-ledger-test
+  (testing "new ledger initializes, accepts transactions, & responds to queries"
+    (let [ledger (test/rand-ledger "file-storage/test")]
+      (is (= 200 (:status (api/transact (:conn test/system) ledger
+                                        [{:_id "_user", "_user/username" "tester"}])))))))

--- a/test/fluree/db/test_helpers.clj
+++ b/test/fluree/db/test_helpers.clj
@@ -9,11 +9,12 @@
             [clojure.edn :as edn]
             [fluree.db.util.json :as json]
             [org.httpkit.client :as http]
-            [fluree.db.api.auth :as fdb-auth])
+            [fluree.db.api.auth :as fdb-auth]
+            [fluree.db.ledger.txgroup.txgroup-proto :as txproto])
   (:import (java.net ServerSocket)
            (java.util UUID)))
 
-(def ^:constant init-timeout-ms 60000)
+(def ^:constant init-timeout-ms 120000)
 
 (defn get-free-port []
   (let [socket (ServerSocket. 0)]
@@ -98,36 +99,38 @@
 (defn wait-for-init
   ([conn ledgers] (wait-for-init conn ledgers init-timeout-ms))
   ([conn ledgers timeout]
-   (loop [elapsed 0
+   (loop [sleep   0
+          elapsed 0
           ledgers ledgers]
-     (let [start         (System/currentTimeMillis)
-           ready-checks  (check-if-ready conn ledgers)
-           ready-ledgers (<!! (async/reduce
-                                (fn [rls [ledger ready?]]
-                                  (assoc rls ledger ready?))
-                                {} ready-checks))]
-       (when (not-every? second ready-ledgers)
-         (Thread/sleep 1000)
-         (let [split   (- (System/currentTimeMillis) start)
-               elapsed (+ elapsed split)]
-           (if (>= elapsed timeout)
-             (throw (RuntimeException.
-                      (str "Waited " elapsed
-                           "ms for test ledgers to initialize. Max is "
-                           timeout "ms.")))
-             (let [poky-ledgers (remove second ready-ledgers)]
-               ; seeing some intermittent failures to initialize sometimes
-               ; so this starts outputting some diagnostic messages once
-               ; we've used up 80% of the timeout; if we figure out what's
-               ; wrong, can remove the (when ...) form below and the (do ...)
-               ; wrapper
-               (when (<= 80 (* 100 (/ elapsed timeout)))
-                 (println "Running out of time for ledgers to init"
-                          (str "(~" (- timeout elapsed) "ms remaining).")
-                          "Waiting on" (count poky-ledgers)
-                          "ledger(s) to initialize:"
-                          (pr-str (map first poky-ledgers))))
-               (recur elapsed (map first (remove second ready-ledgers)))))))))))
+     (let [start (System/currentTimeMillis)]
+       (Thread/sleep sleep)
+       (let [ready-checks  (check-if-ready conn ledgers)
+             ready-ledgers (<!! (async/reduce
+                                  (fn [rls [ledger ready?]]
+                                    (assoc rls ledger ready?))
+                                  {} ready-checks))]
+         (when (not-every? second ready-ledgers)
+           (let [split   (- (System/currentTimeMillis) start)
+                 elapsed (+ elapsed split)]
+             (if (>= elapsed timeout)
+               (throw (RuntimeException.
+                        (str "Waited " elapsed
+                             "ms for test ledgers to initialize. Max is "
+                             timeout "ms.")))
+               (let [poky-ledgers (remove second ready-ledgers)]
+                 ; seeing some intermittent failures to initialize sometimes
+                 ; so this starts outputting some diagnostic messages once
+                 ; we've used up 80% of the timeout; if we figure out what's
+                 ; wrong, can remove the (when ...) form below and the (do ...)
+                 ; wrapper
+                 (when (<= 80 (* 100 (/ elapsed timeout)))
+                   (println "Running out of time for ledgers to init"
+                            (str "(~" (- timeout elapsed) "ms remaining).")
+                            "Waiting on" (count poky-ledgers)
+                            "ledger(s) to initialize:"
+                            (pr-str (map first poky-ledgers))))
+                 (recur 1000 elapsed
+                        (map first (remove second ready-ledgers))))))))))))
 
 
 (defn init-ledgers!
@@ -162,15 +165,47 @@
     name))
 
 
+(defn wait-for-system-ready
+  ([timeout] (wait-for-system-ready system timeout))
+  ([system timeout]
+   (print "Waiting for system to be ready ...") (flush)
+   (loop [sleep   0
+          elapsed 0]
+     (let [start (System/currentTimeMillis)]
+       (Thread/sleep sleep)
+       (print ".") (flush)
+       (let [{:keys [status]} (-> system :group txproto/-state)
+             consensus-type (get-in system [:config :consensus :type])]
+         (if (and
+               (or (= :in-memory consensus-type)
+                   (and (= :raft consensus-type)
+                        (= :leader status)))
+               ;; Sometimes even when this node is the raft leader or using
+               ;; in-memory consensus we still don't yet have a default private
+               ;; key to sign unsigned reqs with; so wait for that too
+               (-> system :group txproto/get-shared-private-key))
+           (println " Ready!")
+           (let [split   (- (System/currentTimeMillis) start)
+                 elapsed (+ elapsed split)]
+             (when (>= elapsed timeout)
+               (throw (RuntimeException.
+                        (str "Waited " elapsed
+                             "ms for system to become ready. Max is "
+                             timeout "ms."))))
+             (recur 1000 elapsed))))))))
+
+
 (defn test-system
   "This fixture is intended to be used like this:
   (use-fixture :once test-system)
-  It starts up an in-memory ledger server for testing. It does not create any
-  ledgers. You might find the rand-ledger fn useful for that."
+  It starts up an in-memory (by default) ledger server for testing and waits
+  for it to be ready to use. It does not create any ledgers. You might find
+  the rand-ledger fn useful for that."
   ([tests] (test-system {} tests))
   ([opts tests]
    (try
      (start* opts)
+     (wait-for-system-ready init-timeout-ms)
      (tests)
      (catch Throwable e
        (log/error e "Caught test exception")


### PR DESCRIPTION
This does a couple of things:

1. It adds an integration test that creates and uses a ledger w/ file storage instead of the memory storage the rest of the tests use. There was a recent bug that only appeared with file storage, and it isn't the first one of its kind. Now we'll have a test that can catch some of those.
2. It fixes a somewhat long-standing race condition in the test suite where it starts trying to create ledgers right after spinning up a test system. Every once in awhile it sent a `:new-db` command before the default private key was added to the group's local-state, and then the command would fail. The test suite now waits for that private key to appear before running the tests. This seems unlikely to come up in production, though.