### PR TITLE
FC-1382: Delete stale files after reindexing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
             org.clojure/data.xml           {:mvn/version "0.2.0-alpha6"}
             com.fluree/alphabase           {:mvn/version "3.2.2"}
             com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                            :sha     "f40263eb71328275b7a5bcfd2ab4db807a7e1bc6"}
+                                            :sha     "2d36b9a60a8627b2bf540f73cdb5f4e7f0f346ba"}
             com.fluree/raft                {:mvn/version "1.0.0-beta1"}
             com.fluree/crypto              {:mvn/version "0.3.9"}
 

--- a/src/fluree/db/ledger/reindex.clj
+++ b/src/fluree/db/ledger/reindex.clj
@@ -210,7 +210,7 @@
            (if (nil? block-data)
              (do (log/info (str "-->> Reindex finished dbid: " dbid " block: " (dec block)))
                  (let [final-db (if (> (get-in db [:novelty :size]) 0)
-                                  (let [indexed-db        (async/<? (indexing/refresh db {:status  status
+                                  (let [indexed-db        (<? (indexing/refresh db {:status  status
                                                                                           :message message
                                                                                           :ecount  ecount}))
                                         group             (-> indexed-db :conn :group)

--- a/src/fluree/db/ledger/reindex.clj
+++ b/src/fluree/db/ledger/reindex.clj
@@ -210,7 +210,7 @@
            (if (nil? block-data)
              (do (log/info (str "-->> Reindex finished dbid: " dbid " block: " (dec block)))
                  (let [final-db (if (> (get-in db [:novelty :size]) 0)
-                                  (let [indexed-db        (async/<! (indexing/refresh db {:status  status
+                                  (let [indexed-db        (async/<? (indexing/refresh db {:status  status
                                                                                           :message message
                                                                                           :ecount  ecount}))
                                         group             (-> indexed-db :conn :group)

--- a/src/fluree/db/ledger/storage/memorystore.clj
+++ b/src/fluree/db/ledger/storage/memorystore.clj
@@ -26,6 +26,13 @@
     (swap! memory-store dissoc key)
     true))
 
+(defn connection-storage-list
+  [_]
+  (go-try
+   (->> @memory-store
+        keys
+        (map (fn [k] {:name k})))))
+
 
 (defn close
   "Resets memory store."

--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -446,7 +446,7 @@
                                            file-ledger-storage-path)
                                    :s3 (s3store/connection-storage-list
                                          s3-conn s3-ledger-storage-prefix)
-                                   :memory nil)
+                                   :memory memorystore/connection-storage-list)
         serializer               (get-serializer settings)
         close-fn                 (case storage-type
                                    :file   (fn [] nil)


### PR DESCRIPTION
This patch identifies all index nodes descended from the current index root, and deletes every other file directly from that Raft group and storage. 