### PR TITLE
Deprecate some things that will go away in 2.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure               {:mvn/version "1.10.3"}
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
-        com.fluree/db                     {:mvn/version "1.0.0-rc34"}
+        com.fluree/db                     {:mvn/version "1.0.0"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 
@@ -35,7 +35,7 @@
  :aliases
  {:mvn/group-id com.fluree
   :mvn/artifact-id ledger
-  :mvn/version "1.0.0-beta19"
+  :mvn/version "1.0.0"
 
   :dev
   {:extra-paths ["dev", "test"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure               {:mvn/version "1.10.3"}
         org.clojure/data.xml              {:mvn/version "0.2.0-alpha6"}
         com.fluree/alphabase              {:mvn/version "3.2.2"}
-        com.fluree/db                     {:mvn/version "1.0.0"}
+        com.fluree/db                     {:mvn/version "1.0.1"}
         com.fluree/raft                   {:mvn/version "1.0.0-beta1"}
         com.fluree/crypto                 {:mvn/version "0.3.7"}
 

--- a/src/fluree/db/ledger/bootstrap.clj
+++ b/src/fluree/db/ledger/bootstrap.clj
@@ -221,32 +221,32 @@
 
 
 (defn bootstrap-db
-  "Bootstraps a new db from a signed new-db message."
+  "Bootstraps a new db from a signed new-ledger message."
   [{:keys [conn group]} command]
   (go-try
     (let [{:keys [cmd sig]} command
-          txid          (crypto/sha3-256 cmd)
-          new-db-name   (-> cmd
-                            (json/parse)
-                            :db)
-          [network dbid] (if (sequential? new-db-name)
-                           new-db-name
-                           (str/split new-db-name #"/"))
-          _             (when (or (txproto/ledger-exists? group network dbid)
-                                  ;; also check for block 1 on disk as a precaution
-                                  (<? (storage/block conn network dbid 1)))
-                          (throw (ex-info (str "Ledger " network "/$" dbid " already exists! Create unsuccessful.")
-                                          {:status 500
-                                           :error  :db/unexpected-error})))
-          master-authid (crypto/account-id-from-message cmd sig)
-          block         (boostrap-memory-db conn [network dbid] {:master-auth-id master-authid :txid txid :cmd cmd :sig sig})
-          new-db        (:db block)
-          block-data    (dissoc block :db)
-          _             (<? (storage/write-block conn network dbid block-data))
+          txid            (crypto/sha3-256 cmd)
+          new-ledger-name (-> cmd
+                              (json/parse)
+                              :ledger)
+          [network dbid] (if (sequential? new-ledger-name)
+                           new-ledger-name
+                           (str/split new-ledger-name #"/"))
+          _               (when (or (txproto/ledger-exists? group network dbid)
+                                    ;; also check for block 1 on disk as a precaution
+                                    (<? (storage/block conn network dbid 1)))
+                            (throw (ex-info (str "Ledger " network "/$" dbid " already exists! Create unsuccessful.")
+                                            {:status 500
+                                             :error  :db/unexpected-error})))
+          master-authid   (crypto/account-id-from-message cmd sig)
+          block           (boostrap-memory-db conn [network dbid] {:master-auth-id master-authid :txid txid :cmd cmd :sig sig})
+          new-db          (:db block)
+          block-data      (dissoc block :db)
+          _               (<? (storage/write-block conn network dbid block-data))
           ;; todo - should create a new command to register new DB that first checks raft
-          _             (<? (txproto/register-genesis-block-async (:group conn) network dbid))
+          _               (<? (txproto/register-genesis-block-async (:group conn) network dbid))
           ;block-point-success? (async/<! (txproto/propose-new-block-async (:group conn) network dbid block-data))
-          indexed-db    (<? (indexing/index new-db))]
+          indexed-db      (<? (indexing/index new-db))]
       ;; write out new index point
       (<? (txproto/initialized-ledger-async (-> indexed-db :conn :group) txid (:network indexed-db) (:dbid indexed-db)
                                             (:block indexed-db) (:fork indexed-db) (get-in indexed-db [:stats :indexed])))

--- a/src/fluree/db/ledger/consensus/none.clj
+++ b/src/fluree/db/ledger/consensus/none.clj
@@ -71,9 +71,9 @@
                                     is-next-block? (if current-block
                                                      (= block (inc current-block))
                                                      (= 1 block))]
-                                ;; if :new-db in cmd-types, then register new-db
-                                (when (cmd-types :new-db)
-                                  (update-state/register-new-dbs txns state-atom block-map))
+                                ;; if :new-ledger in cmd-types, then register new-ledger
+                                (when (cmd-types :new-ledger)
+                                  (update-state/register-new-ledgers txns state-atom block-map))
 
                                 (if is-next-block?
                                   (do
@@ -94,9 +94,9 @@
                                                :state-dump     @state-atom}) false)))
 
                    ;; stages a new db to be created
-                   :new-db (update-state/stage-new-db entry state-atom)
+                   :new-ledger (update-state/stage-new-db entry state-atom)
 
-                   :initialized-db (update-state/initialized-db entry state-atom)
+                   :initialized-ledger (update-state/initialized-db entry state-atom)
 
                    :new-index (update-state/new-index entry state-atom)
 

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -429,9 +429,9 @@
 (defn ->tx-state
   [db block-instant {:keys [auth auth-sid authority authority-sid tx-permissions txid cmd sig nonce type] :as tx-map}]
   (let [tx-type   (keyword type)
-        tx        (case tx-type                             ;; command type is either :tx or :new-db
+        tx        (case tx-type                             ;; command type is either :tx or :new-ledger
                     :tx (:tx tx-map)
-                    :new-db (tx-util/create-new-db-tx tx-map))
+                    :new-ledger (tx-util/create-new-ledger-tx tx-map))
         db-before (cond-> db
                           tx-permissions (assoc :permissions tx-permissions))]
     {:db-before        db-before
@@ -480,7 +480,6 @@
      :validate-fn      (atom {:queue   (list) :cache {}
                               ;; need to track respective flakes for predicates (for tx-spec) and subject changes (collection-specs)
                               :tx-spec nil :c-spec nil})}))
-
 
 
 (defn resolve-temp-flakes

--- a/src/fluree/db/ledger/txgroup/monitor.clj
+++ b/src/fluree/db/ledger/txgroup/monitor.clj
@@ -365,18 +365,6 @@
             (async/put! (db-queue conn network dbid) ::kick))
           true)))))
 
-(defn new-db?
-  "Returns [network dbid] if state update involves a new db.
-
-  Monitors for :new-block commands, which look like this:
-  [op network dbid block-map submission-server]"
-  [state-change]
-  (let [{:keys [command result]} state-change]
-    (when (and (contains? (:cmd-types (nth command 3)) :new-db)
-               (true? result))
-      ;; we have a new DB!
-      ;; return network db is within
-      (second command))))
 
 (defn state-updates-monitor
   "Function to be called with every state change, to possibly kick of an action.
@@ -389,17 +377,17 @@
   (let [op   (get-in state-change [:command 0])
         conn (:conn system)]
     (case op
-      :new-db
+      :new-ledger
       (future
         (when (txproto/-is-leader? (:group conn))
           (let [initialize-dbs (txproto/find-all-dbs-to-initialize (:group conn))]
             (doseq [[network dbid command] initialize-dbs]
-              (let [db      (async/<!! (bootstrap/bootstrap-db system command))
+              (let [_db     (async/<!! (bootstrap/bootstrap-db system command))
                     session (session/session conn [network dbid])]
                 ;; force session close, so next request will cause session to keep in sync
                 (session/close session))))))
 
-      :initialized-db
+      :initialized-ledger
       (future
         (when-not (txproto/-is-leader? (:group conn))
           (let [command (:command state-change)

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -207,11 +207,11 @@ or this server is not responsible for this ledger, will return false. Else true 
   [conn]
   (let [group-raft    (:group conn)
         current-state @(:state-atom group-raft)
-        db-list       (ledger-list* current-state)]
+        ledger-list   (ledger-list* current-state)]
     (mapv (fn [[network ledger]]
             (-> (ledger-info group-raft network ledger)
                 (assoc :network network :ledger ledger)))
-          db-list)))
+          ledger-list)))
 
 (defn update-ledger-status
   [group network ledger-id status-msg]

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -226,7 +226,7 @@ or this server is not responsible for this ledger, will return false. Else true 
                                     :fork      fork
                                     :forkBlock (when fork block)
                                     :index     index})
-        command [:initialized-db cmd-id network ledger-id status]]
+        command [:initialized-ledger cmd-id network ledger-id status]]
     (-new-entry-async group command)))
 
 (defn lowercase-all-names
@@ -236,7 +236,7 @@ or this server is not responsible for this ledger, will return false. Else true 
 (defn new-ledger-async
   "Registers new network to be created by leader."
   [group network ledger-id cmd-id signed-cmd]
-  (let [command [:new-db network ledger-id cmd-id signed-cmd]]
+  (let [command [:new-ledger network ledger-id cmd-id signed-cmd]]
     (-new-entry-async group command)))
 
 (defn find-all-dbs-to-initialize

--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -405,7 +405,6 @@
          :ledger-stats (future ;; as thread/future - otherwise if this needs to load new db will have new requests and will permanently block
                          (ledger-stats system arg success! error!))
 
-         ;; TODO - change command and all internal calls to :ledger-list, deprecate :db-list
          :ledger-list (let [response (txproto/ledger-list (:group system))]
                         (success! response))
 

--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -27,7 +27,7 @@
   "Does sanity checks for a new command and if valid, propagates it.
   Returns command-id/txid upon successful persistence to network, else
   throws."
-  [{:keys [conn] :as system}  {:keys [cmd sig] :as signed-cmd}]
+  [{:keys [conn] :as system} {:keys [cmd sig] :as signed-cmd}]
   (when-not (and (string? cmd) (string? sig))
     (throw-invalid-command (str "Command map requires keys of 'cmd' and 'sig', with a json string command map and signature of the command map respectively. Provided: " (pr-str signed-cmd))))
   (when (> (count cmd) 10000000)
@@ -43,9 +43,9 @@
                    (crypto/account-id-from-message cmd sig)
                    (catch Exception _ (throw-invalid-command "Invalid signature on command.")))]
     (case cmd-type
-      :tx (let [{:keys [db tx deps expire nonce]} cmd-data
-                _ (when-not db (throw-invalid-command "No db specified for transaction."))
-                [network dbid] (session/resolve-ledger conn db)]
+      :tx (let [{:keys [ledger tx deps expire nonce]} cmd-data
+                _ (when-not ledger (throw-invalid-command "No ledger specified for transaction."))
+                [network dbid] (session/resolve-ledger conn ledger)]
 
             (when-not tx
               (throw-invalid-command "No tx specified for transaction."))
@@ -54,7 +54,7 @@
             (when (and expire (or (not (pos-int? expire)) (< expire (System/currentTimeMillis))))
               (throw-invalid-command (format "Transaction 'expire', when provided, must be epoch millis and be later than now. expire: %s current time: %s" expire (System/currentTimeMillis))))
             (when-not (txproto/ledger-exists? (:group system) network dbid)
-              (throw-invalid-command (str "The database does not exist within this ledger group: " db)))
+              (throw-invalid-command (str "Ledger does not exist: " ledger)))
             (when (and nonce (not (int? nonce)))
               (throw-invalid-command (format "Nonce, if provided, must be an integer. Provided: %s" nonce)))
             (async/<!! (txproto/queue-command-async (:group system) network dbid id signed-cmd))
@@ -109,47 +109,51 @@
                           {:status 400
                            :error  :db/invalid-action}))))
 
-      :new-db (let [{:keys [db snapshot auth expire nonce]} cmd-data
-                    [network dbid] (if (sequential? db) db (str/split db #"/"))]
-                (when (and auth auth-id (not= auth auth-id))
-                  (throw-invalid-command (str "New-db command was signed by auth: " auth-id " but the command specifies auth: " auth ". They must be the same if auth is provided.")))
-                (when-not (re-matches #"^[a-z0-9-]+$" network)
-                  (throw-invalid-command (str "Invalid network name: " network)))
-                (when-not (re-matches #"^[a-z0-9-]+$" dbid)
-                  (throw-invalid-command (str "Invalid db name: " dbid)))
-                (when (and expire (or (not (pos-int? expire)) (< expire (System/currentTimeMillis))))
-                  (throw-invalid-command (format "Transaction 'expire', when provided, must be epoch millis and be later than now. expire: %s current time: %s" expire (System/currentTimeMillis))))
-                (when (and nonce (not (int? nonce)))
-                  (throw-invalid-command (format "Nonce, if provided, must be an integer. Provided: %s" nonce)))
-                (when ((set (txproto/all-ledger-list (:group system))) [network dbid])
-                  (throw-invalid-command (format "Cannot create a new db, it already exists or existed: %s" db)))
-                (when snapshot
-                  (let [storage-exists? (-> system :conn :storage-exists)
-                        exists?         (storage-exists? (str snapshot))]
-                    (when-not exists?
-                      (throw-invalid-command
-                        (format "Cannot create a new db, snapshot file, %s, does not exist in storage, %s"
-                                snapshot (case (-> system :conn :storage-type)
-                                           :s3 (-> system :conn :meta :s3-storage)
-                                           :file (-> system :conn :meta :file-storage-path)
-                                           (-> system :conn :storage-type)))))))
+      :new-ledger (let [{:keys [ledger snapshot auth expire nonce]} cmd-data
+                        [network dbid] (if (sequential? ledger) ledger (str/split ledger #"/"))]
+                    (when (and auth auth-id (not= auth auth-id))
+                      (throw-invalid-command (str "New-ledger command was signed by auth: " auth-id " but the command specifies auth: " auth ". They must be the same if auth is provided.")))
+                    (when-not (re-matches #"^[a-z0-9-]+$" network)
+                      (throw-invalid-command (str "Invalid network name: " network)))
+                    (when-not (re-matches #"^[a-z0-9-]+$" dbid)
+                      (throw-invalid-command (str "Invalid ledger name: " dbid)))
+                    (when (and expire (or (not (pos-int? expire)) (< expire (System/currentTimeMillis))))
+                      (throw-invalid-command (format "Transaction 'expire', when provided, must be epoch millis and be later than now. expire: %s current time: %s" expire (System/currentTimeMillis))))
+                    (when (and nonce (not (int? nonce)))
+                      (throw-invalid-command (format "Nonce, if provided, must be an integer. Provided: %s" nonce)))
+                    (when ((set (txproto/all-ledger-list (:group system))) [network dbid])
+                      (throw-invalid-command (format "Cannot create a new ledger, it already exists or existed: %s" ledger)))
+                    (when snapshot
+                      (let [storage-exists? (-> system :conn :storage-exists)
+                            exists?         (storage-exists? (str snapshot))]
+                        (when-not exists?
+                          (throw-invalid-command
+                            (format "Cannot create a new ledger, snapshot file, %s, does not exist in storage, %s"
+                                    snapshot (case (-> system :conn :storage-type)
+                                               :s3 (-> system :conn :meta :s3-storage)
+                                               :file (-> system :conn :meta :file-storage-path)
+                                               (-> system :conn :storage-type)))))))
 
-                ;; TODO - do more validation, reconcile with "unsigned-cmd" validation before this
+                    ;; TODO - do more validation, reconcile with "unsigned-cmd" validation before this
 
-                (async/<!! (txproto/new-ledger-async (:group system) network dbid id signed-cmd))
+                    (async/<!! (txproto/new-ledger-async (:group system) network dbid id signed-cmd))
 
-                id)
-      :delete-db (let [{:keys [db]} cmd-data
-                       [network dbid] (if (sequential? db) db (str/split db #"/"))
-                       old-session    (session/session conn db)
-                       db*            (async/<!! (session/current-db old-session))
-                       _ (when-not (or (-> system :group :open-api)
-                                       (async/<!! (auth/root-role? db* ["_auth/id" auth-id])))
-                           (throw (ex-info (str "To delete a ledger, must be using an open API or an auth record with a root role.")
-                                           {:status 401 :error :db/invalid-auth})))]
-                   (async/<!! (ledger-delete/process conn network dbid))
-                   (session/close old-session))
-      :default-key (let [{:keys [expire nonce network dbid private-key]} cmd-data
+                    id)
+      :delete-ledger (let [{:keys [ledger]} cmd-data
+                           [network dbid] (if (sequential? ledger) ledger (str/split ledger #"/"))
+                           old-session (session/session conn ledger)
+                           db          (async/<!! (session/current-db old-session))
+                           _           (when-not (or (-> system :group :open-api)
+                                                     (async/<!! (auth/root-role? db ["_auth/id" auth-id])))
+                                         (throw (ex-info (str "To delete a ledger, must be using an open API or an auth record with a root role.")
+                                                         {:status 401 :error :db/invalid-auth})))]
+                       (async/<!! (ledger-delete/process conn network dbid))
+                       (session/close old-session))
+      :default-key (let [{:keys [expire nonce network dbid ledger-id private-key]} cmd-data
+                         ledger-id (or ledger-id
+                                       (when dbid
+                                         (log/warn "'dbid' param is deprecated. Please use 'ledger-id' instead.")
+                                         dbid))
                          default-auth-id (some-> (txproto/get-shared-private-key (:group system))
                                                  (crypto/account-id-from-private))
                          network-auth-id (some->> network
@@ -165,13 +169,13 @@
                        (throw-invalid-command (format "Transaction 'expire', when provided, must be epoch millis and be later than now. expire: %s current time: %s" expire (System/currentTimeMillis))))
                      (when (and nonce (not (int? nonce)))
                        (throw-invalid-command (format "Nonce, if provided, must be an integer. Provided: %s" nonce)))
-                     (when (and dbid (not (string? dbid)))
-                       (throw-invalid-command (str "Dbid must be a string if provided. Provided: " (pr-str dbid))))
+                     (when (and ledger-id (not (string? ledger-id)))
+                       (throw-invalid-command (str "Ledger-id must be a string if provided. Provided: " (pr-str ledger-id))))
                      (when (and network (not (string? network)))
                        (throw-invalid-command (str "Network must be a string if provided. Provided: " (pr-str network))))
                      (cond
-                       (and network dbid)
-                       (txproto/set-shared-private-key (:group system) network dbid private-key)
+                       (and network ledger-id)
+                       (txproto/set-shared-private-key (:group system) network ledger-id private-key)
 
                        network
                        (txproto/set-shared-private-key (:group system) network private-key)
@@ -199,7 +203,7 @@
         (error! (ex-info (str "Invalid ledger: " ledger)
                          {:status 400 :error :db/invalid-ledger}))
         (let [ledger-info (ledger-info system network dbid)
-              db-stat     (when (and (seq ledger-info)      ;; skip stats if db is still initializing
+              db-stat     (when (and (seq ledger-info) ;; skip stats if db is still initializing
                                      (not= :initialize (:status ledger-info)))
 
                             (let [session-db (async/<! (session/db (:conn system) ledger {}))]
@@ -216,18 +220,23 @@
    (message-handler system producer-chan (str (util/random-uuid)) msg))
   ([system producer-chan ws-id msg]
    (let [[operation req-id arg] msg
-         success! (fn [resp] (async/put! producer-chan [:response req-id resp nil]))
-         error!   (fn [e]
-                    (let [exdata     (ex-data e)
-                          status     (or (:status exdata) 500)
-                          error      (or (:error exdata) :db/unexpected-error)
-                          error-resp {:message (ex-message e)
-                                      :status  status
-                                      :error   error}]
-                      ;; log any unexpected errors locally
-                      (when (>= status 500)
-                        (log/error e (str "Unexpected error processing message: " (pr-str msg))))
-                      (async/put! producer-chan [:response req-id nil error-resp])))]
+         operation (if (str/includes? operation "db")
+                     (let [new-op (-> operation name (str/replace "db" "ledger"))]
+                       (log/warn (str "'" operation "' is deprecated. Please use '" new-op "' instead."))
+                       new-op)
+                     operation)
+         success!  (fn [resp] (async/put! producer-chan [:response req-id resp nil]))
+         error!    (fn [e]
+                     (let [exdata     (ex-data e)
+                           status     (or (:status exdata) 500)
+                           error      (or (:error exdata) :db/unexpected-error)
+                           error-resp {:message (ex-message e)
+                                       :status  status
+                                       :error   error}]
+                       ;; log any unexpected errors locally
+                       (when (>= status 500)
+                         (log/error e (str "Unexpected error processing message: " (pr-str msg))))
+                       (async/put! producer-chan [:response req-id nil error-resp])))]
      (log/trace "Incoming message: " (pr-str msg))
      (try
        (case (keyword operation)
@@ -242,8 +251,8 @@
                          has-auth? (-> (get-in @subscription-auth [ws-id])
                                        (as-> wsm (reduce-kv (fn [res _ val] (if (map? val) (into res (vals val)) res)) [] wsm))
                                        seq)]
-                     (cond-> {:open-api?          open-api?
-                              :password-enabled?  (-> system :conn pw-auth/password-enabled?)}
+                     (cond-> {:open-api?         open-api?
+                              :password-enabled? (-> system :conn pw-auth/password-enabled?)}
                              (or open-api? has-auth?) (assoc :jwt-secret (-> system :conn :meta :password-auth :secret
                                                                              (ab-core/byte-array-to-base :hex)))
                              true success!))
@@ -260,7 +269,7 @@
                                                  (sequential? (first arg)) ;; [ [network, dbid], auth ]
                                                  arg
 
-                                                 :else      ;; network/dbid or [network, dbid]
+                                                 :else ;; network/dbid or [network, dbid]
                                                  [arg])
 
                           auth        (cond
@@ -299,12 +308,12 @@
                                      ;; Expect [ [network, dbid], auth ] or [network, dbid] or network/dbid
                                      (first arg)
                                      arg)
-                            dbv (session/resolve-ledger (:conn system) ledger)
+                            dbv    (session/resolve-ledger (:conn system) ledger)
                             [network dbid] dbv
-                            _   (when-not (txproto/ledger-exists? (:group system) network dbid)
-                                  (throw (ex-info (str "Db " dbv " does not exist on this ledger.")
-                                                  {:status 400 :error :db/invalid-db})))
-                            _   (swap! subscription-auth update-in [ws-id network] dbid)]
+                            _      (when-not (txproto/ledger-exists? (:group system) network dbid)
+                                     (throw (ex-info (str "Ledger " dbv " does not exist.")
+                                                     {:status 400 :error :db/invalid-db})))
+                            _      (swap! subscription-auth update-in [ws-id network] dbid)]
                         (event-bus/unsubscribe-db dbv producer-chan)
                         (success! true))
 
@@ -327,23 +336,32 @@
          :nw-unsubscribe (raft/monitor-raft-stop (-> system :group))
 
          :unsigned-cmd (let [cmd-data    arg
-                             {:keys [db jwt]} cmd-data
-                             cmd-type    (keyword (:type cmd-data))
-                             _           (when-not (#{:tx :new-db :default-key :delete-db} cmd-type)
+                             {:keys [type ledger db jwt]} cmd-data
+                             ledger      (or ledger
+                                             (when db
+                                               (log/warn "'db' param is deprecated in commands. Please use 'ledger' instead.")
+                                               db))
+                             cmd-type    (if (str/includes? type "db")
+                                           (let [new-cmd-type (-> type name (str/replace "db" "ledger") keyword)]
+                                             (log/warn
+                                               (str "'" type "' command is deprecated. Please use '" new-cmd-type "' instead."))
+                                             new-cmd-type)
+                                           type)
+                             _           (when-not (#{:tx :new-ledger :default-key :delete-ledger} cmd-type)
                                            (throw-invalid-command (str "Invalid command type (:type) provided in unsigned command: " (:type cmd-data))))
                              [network dbid] (cond
-                                              (= :new-db cmd-type)
+                                              (= :new-ledger cmd-type)
                                               (cond
-                                                (string? db) (str/split db #"/")
-                                                (sequential? db) db
-                                                :else (throw (ex-info (str "Invalid db provided for new-db: " (pr-str db))
+                                                (string? ledger) (str/split ledger #"/")
+                                                (sequential? ledger) ledger
+                                                :else (throw (ex-info (str "Invalid ledger provided for new-ledger: " (pr-str ledger))
                                                                       {:status 400 :error :db/invalid-command})))
 
-                                              (= :delete-db cmd-type)
-                                              (session/resolve-ledger (:conn system) db)
+                                              (= :delete-ledger cmd-type)
+                                              (session/resolve-ledger (:conn system) ledger)
 
                                               (= :tx cmd-type)
-                                              (session/resolve-ledger (:conn system) db)
+                                              (session/resolve-ledger (:conn system) ledger)
 
                                               (= :default-key cmd-type)
                                               (let [{:keys [network dbid]} cmd-data]
@@ -358,50 +376,55 @@
                              expire      (or expire (+ 60000 nonce))
                              cmd-data*   (assoc cmd-data :expire expire :nonce nonce)]
                          (when (< expire (System/currentTimeMillis))
-                           (throw-invalid-command (format "Command expired. Expiration: %s. Current time: %s." expire (System/currentTimeMillis))))
-                         (when (and (= :new-db cmd-type)
+                           (throw-invalid-command (format "Command expired. Expiration: %s. Current time: %s."
+                                                          expire (System/currentTimeMillis))))
+                         (when (and (= :new-ledger cmd-type)
                                     (txproto/ledger-exists? (:group system) network dbid))
-                           (throw-invalid-command (str "The database already exists or existed: " db)))
+                           (throw-invalid-command (str "The ledger already exists or existed: " ledger)))
                          (when (and (= :tx cmd-type)
                                     (not (txproto/ledger-exists? (:group system) network dbid)))
-                           (throw-invalid-command (str "The database does not exist within this ledger group: " db)))
+                           (throw-invalid-command (str "Ledger does not exist: " ledger)))
                          (when-not private-key
                            (throw-invalid-command (str "The ledger group is not configured with a default private "
-                                                       "key for use with database: " db ". Unable to process an unsigned "
+                                                       "key for use with ledger: " ledger ". Unable to process an unsigned "
                                                        "transaction.")))
                          (let [cmd        (-> cmd-data*
                                               (util/without-nils)
                                               (json/stringify))
                                sig        (crypto/sign-message cmd private-key)
                                id         (crypto/sha3-256 cmd)
-                               signed-cmd {:cmd cmd
-                                           :sig sig
-                                           :id  id
-                                           :db  db}]
+                               signed-cmd {:cmd    cmd
+                                           :sig    sig
+                                           :id     id
+                                           :ledger ledger}]
                            (success! (process-command system signed-cmd))))
 
          :ledger-info (let [[network dbid] (session/resolve-ledger (:conn system) arg)]
                         (success! (ledger-info system network dbid)))
 
-         :ledger-stats (future                              ;; as thread/future - otherwise if this needs to load new db will have new requests and will permanently block
+         :ledger-stats (future ;; as thread/future - otherwise if this needs to load new db will have new requests and will permanently block
                          (ledger-stats system arg success! error!))
 
          ;; TODO - change command and all internal calls to :ledger-list, deprecate :db-list
-         :db-list (let [response (txproto/ledger-list (:group system))]
-                    (success! response))
+         :ledger-list (let [response (txproto/ledger-list (:group system))]
+                        (success! response))
 
          ;; TODO - unsigned-cmd should cover a 'tx', remove below
          :tx (let [tx-map      arg
-                   {:keys [db tx]} tx-map
-                   [network dbid] (session/resolve-ledger (:conn system) db)
+                   {:keys [ledger db tx]} tx-map
+                   ledger      (or ledger
+                                   (when db
+                                     (log/warn "'db' param in a transaction is deprecated. Please use 'ledger' instead.")
+                                     db))
+                   [network dbid] (session/resolve-ledger (:conn system) ledger)
                    _           (when-not (txproto/ledger-exists? (:group system) network dbid)
-                                 (throw-invalid-command (str "The database does not exist within this ledger group: " db)))
+                                 (throw-invalid-command (str "Ledger does not exist: " ledger)))
                    private-key (txproto/get-shared-private-key (:group system) network dbid)
                    _           (when-not private-key
                                  (throw-invalid-command (str "The ledger group is not configured with a default private "
-                                                             "key for use with database: " db ". Unable to process an unsigned "
+                                                             "key for use with ledger: " ledger ". Unable to process an unsigned "
                                                              "transaction.")))
-                   cmd         (fdb/tx->command db tx private-key tx-map)]
+                   cmd         (fdb/tx->command ledger tx private-key tx-map)]
                (success! (process-command system cmd)))
 
          :pw-login (let [{:keys [ledger password user auth]} arg]
@@ -467,9 +490,9 @@
                               (success! jwt))))))
 
        (catch Exception e
-         (log/info "Error caught in incoming message handler: "
-                   {:error   (ex-message e)
-                    :message msg})
+         (log/error {:error   e
+                     :message msg}
+                   "Error caught in incoming message handler:")
          (error! e))))))
 
 

--- a/test/fluree/db/ledger/docs/identity/auth.clj
+++ b/test/fluree/db/ledger/docs/identity/auth.clj
@@ -3,6 +3,7 @@
             [fluree.db.test-helpers :as test]
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.api :as fdb]
+            [fluree.db.api.auth :as fdb-auth]
             [clojure.core.async :as async]
             [clojure.string :as str]))
 
@@ -10,7 +11,7 @@
 
 ; Add new auth record with permissions and test
 (deftest viewPersonNoHandle
-  (let [{:keys [private public id]} (fdb/new-private-key)
+  (let [{:keys [private public id]} (fdb-auth/new-private-key)
         addAuth         [{:_id   "_auth"
                           :id    id
                           :roles ["_role$standardUser"]}
@@ -60,7 +61,7 @@
 
 (deftest createAuthority
   ;; TODO - sometimes fails, does this have to do with padding in crypto?
-  (let [{:keys [private public id]} (fdb/new-private-key)
+  (let [{:keys [private public id]} (fdb-auth/new-private-key)
         opts          {:timeout 240000}
         addAuth       [{:_id "_auth$authority"
                         :id  id}

--- a/test/fluree/db/ledger/docs/identity/signatures.clj
+++ b/test/fluree/db/ledger/docs/identity/signatures.clj
@@ -4,6 +4,7 @@
             [fluree.db.ledger.docs.getting-started.basic-schema :as basic]
             [fluree.db.ledger.api.downloaded :as downloaded]
             [fluree.db.api :as fdb]
+            [fluree.db.api.auth :as fdb-auth]
             [org.httpkit.client :as http]
             [clojure.core.async :as async]
             [fluree.db.util.json :as json]
@@ -28,7 +29,7 @@
 (defn add-keys-to-atom
   [n]
   (dotimes [k n]
-    (swap! key-maps assoc k (fdb/new-private-key))))
+    (swap! key-maps assoc k (fdb-auth/new-private-key))))
 
 
 (defn send-parse-request

--- a/test/fluree/db/ledger/general/invoice_tests.clj
+++ b/test/fluree/db/ledger/general/invoice_tests.clj
@@ -91,7 +91,7 @@
           antonio-res (-> antonio
                           :auth
                           query-as
-                          (get-values-for-key "invoice/id"))   ]
+                          (get-values-for-key "invoice/id"))]
 
       (is (= #{"A-000" "B-000"} (set root-res)))
       (is (= #{"A-000"} (set scott-res)))

--- a/test/fluree/db/peer/query_peer_tests.clj
+++ b/test/fluree/db/peer/query_peer_tests.clj
@@ -39,14 +39,14 @@
                             :fdb-storage-type       "memory"
                             :fdb-consensus-type     "in-memory"})]
     (testing "can create a ledger"
-      (let [new-ledger1       @(http/post (str "http://localhost:" query-port "/fdb/new-db")
+      (let [new-ledger1       @(http/post (str "http://localhost:" query-port "/fdb/new-ledger")
                                           {:headers {"content-type" "application/json"}
                                            :body    (json/stringify {:db/id "test/test1"})})
-            new-ledger2       @(http/post (str "http://localhost:" ledger-port "/fdb/new-db")
+            new-ledger2       @(http/post (str "http://localhost:" ledger-port "/fdb/new-ledger")
                                           {:headers {"content-type" "application/json"}
                                            :body    (json/stringify {:db/id "test/test2"})})
-            ledger-list-resp1 @(http/post (str "http://localhost:" query-port "/fdb/dbs"))
-            ledger-list-resp2 @(http/post (str "http://localhost:" ledger-port "/fdb/dbs"))
+            ledger-list-resp1 @(http/post (str "http://localhost:" query-port "/fdb/ledgers"))
+            ledger-list-resp2 @(http/post (str "http://localhost:" ledger-port "/fdb/ledgers"))
             ;; wait for initialization!
             _                 (Thread/sleep 2000)
             ledger1-ready?    @(http/post (str "http://localhost:" query-port "/fdb/test/test1/ledger-stats"))

--- a/test/fluree/db/test_helpers.clj
+++ b/test/fluree/db/test_helpers.clj
@@ -4,9 +4,7 @@
             [fluree.db.server :as server]
             [fluree.db.api :as fdb]
             [fluree.db.server-settings :as setting]
-            [fluree.db.util.log :as log]
-            [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
-            [clojure.string :as str])
+            [fluree.db.util.log :as log])
   (:import (java.net ServerSocket)))
 
 (defn get-free-port []

--- a/test/fluree/db/test_helpers.clj
+++ b/test/fluree/db/test_helpers.clj
@@ -4,7 +4,9 @@
             [fluree.db.server :as server]
             [fluree.db.api :as fdb]
             [fluree.db.server-settings :as setting]
-            [fluree.db.util.log :as log])
+            [fluree.db.util.log :as log]
+            [fluree.db.ledger.txgroup.txgroup-proto :as txproto]
+            [clojure.string :as str])
   (:import (java.net ServerSocket)))
 
 (defn get-free-port []


### PR DESCRIPTION
Deprecates db where we mean ledger (but hopefully retains compatibility with the old forms; just logs a warning) and warns about not using add-server and remove-server (vs. statically configuring 3 or 5 raft servers).

Counterpart to https://github.com/fluree/db/pull/168

Targets a new `maintenance/v1` that is branched from `v1.0.0-beta19`.