### PR TITLE
Ensure that :txid-only defaults to false in /command HTTP API endpoint

### DIFF
--- a/test/fluree/db/ledger/api/downloaded.clj
+++ b/test/fluree/db/ledger/api/downloaded.clj
@@ -634,11 +634,14 @@
 
 (deftest command-add-person
   (testing "Issue a signed command to add a person."
-    (let [privKey (slurp "default-private-key.txt")
-          cmd-map (fdb/tx->command test/ledger-endpoints [{:_id "person" :stringNotUnique "JoAnne"}]
-                                   privKey)
-          res     @(http/post (str endpoint-url "command") (standard-request cmd-map))
-          body    (-> res :body bs/to-string json/parse)]
+    (let [priv-key (slurp "default-private-key.txt")
+          cmd-map  (assoc (fdb/tx->command test/ledger-endpoints
+                                           [{:_id "person" :stringNotUnique "JoAnne"}]
+                                           priv-key)
+                     :txid-only true)
+          res      @(http/post (str endpoint-url "command")
+                               (standard-request cmd-map))
+          body     (-> res :body bs/to-string json/parse)]
 
       (is (= 200 (:status res)))
 


### PR DESCRIPTION
The old code defaulted to true when the param was omitted, unlike everywhere else where it defaults to false.