### PR TITLE
Add release-prerelease target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,13 @@ prep-release: check-release-jdk-version clean build/fluree-$(VERSION).zip build/
 release: prep-release
 	aws s3 sync build/release-staging/ s3://$(RELEASE_BUCKET)/ --size-only --cache-control max-age=300 --acl public-read --profile fluree
 
-release-stable: prep-release
-	cp build/release-staging/fluree-$(VERSION).zip build/release-staging/fluree-stable.zip
-	cp build/release-staging/fluree-$(VERSION).zip build/release-staging/fluree-latest.zip
+release-prerelease: prep-release
+	cp build/release-staging/fluree-$(VERSION).zip build/release-staging/fluree-prerelease.zip
 	cp build/release-staging/fluree-$(VERSION).zip build/release-staging/fluree-$(MAJOR_VERSION).$(MINOR_VERSION)-latest.zip
 	aws s3 sync build/release-staging/ s3://$(RELEASE_BUCKET)/ --size-only --cache-control max-age=300 --acl public-read --profile fluree
 
 release-latest: prep-release
 	cp build/release-staging/fluree-$(VERSION).zip build/release-staging/fluree-latest.zip
-	cp build/release-staging/fluree-$(VERSION).zip build/release-staging/fluree-stable.zip
 	cp build/release-staging/fluree-$(VERSION).zip build/release-staging/fluree-$(MAJOR_VERSION).$(MINOR_VERSION)-latest.zip
 	aws s3 sync build/release-staging/ s3://$(RELEASE_BUCKET)/ --size-only --cache-control max-age=300 --acl public-read --profile fluree
 


### PR DESCRIPTION
...and remove old "stable" filename.

Our new release naming scheme is latest and prerelease (originally I we had discussed "beta" but we currently have an "alpha" so need something more generic like "prerelease"; happy to hear other suggestions for that, though).

I have a website edit draft waiting on this to land so we can publish the 2.x ZIP files as downloadable from the website.

At some point it would be good to indicate the version being downloaded more readily. It would be nice to show it on the website, but I'm not totally sure how to do that w/o manual edits each time (which I don't think we should do). But maybe at the very least have the file download as fluree-{version}.zip instead of fluree-latest.zip / fluree-prerelease.zip. But I'm not doing any of that here. :)