### PR TITLE
Fix FC-1414 block not found

### DIFF
--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -779,10 +779,10 @@
                                            (throw (ex-info (str "If using a closed api, a storage request must be returned as json.")
                                                            {:status 401
                                                             :error  :db/invalid-transaction})))
-                        {network :network dbid :ledger type :type key :key} params
-                        ledger        (keyword network ledger)
-                        _                (when-not (and network dbid type)
-                                           (throw (ex-info (str "Incomplete request. At least a network, db and type are required. Provided network: " network " ledger: " dbid " type: " type " key: " key)
+                        {network :network ledger-id :ledger type :type key :key} params
+                        ledger        (keyword network ledger-id)
+                        _                (when-not (and network ledger-id type)
+                                           (throw (ex-info (str "Incomplete request. At least a network, db and type are required. Provided network: " network " ledger: " ledger-id " type: " type " key: " key)
                                                            {:status 400 :error :db/invalid-request})))
                         auth-id          (cond
 
@@ -794,7 +794,7 @@
 
                                                  {:keys [auth authority]} (http-signatures/verify-request*
                                                                             {:headers headers} :get
-                                                                            (str "/fdb/storage/" network "/" dbid
+                                                                            (str "/fdb/storage/" network "/" ledger-id
                                                                                  (when type (str "/" type))
                                                                                  (when key (str "/" key))) host)
                                                  db          (<? (fdb/db (:conn system) ledger))]
@@ -811,7 +811,8 @@
                                                             (throw (ex-info (str "Auth id for request does not exist in the database: " jwt-auth)
                                                                             {:status 403 :error :db/invalid-auth})))]
                                              jwt-auth))
-                        formatted-key    (cond-> (str network "_" dbid "_" type)
+                        ;; TODO: use storage-core/format-block-key once it's available
+                        formatted-key    (cond-> (str network "_" ledger-id "_" type)
                                            key (str "_" key))
 
                         avro-data        (<? (storage-read-fn formatted-key))

--- a/src/fluree/db/peer/messages.clj
+++ b/src/fluree/db/peer/messages.clj
@@ -362,9 +362,9 @@
                                              (log/warn
                                                (str "'" type "' command is deprecated. Please use '" new-cmd-type "' instead."))
                                              new-cmd-type)
-                                           type)
+                                           (keyword type))
                              _           (when-not (#{:tx :new-ledger :default-key :delete-ledger} cmd-type)
-                                           (throw-invalid-command (str "Invalid command type (:type) provided in unsigned command: " (:type cmd-data))))
+                                           (throw-invalid-command (str "Invalid command type (:type) provided in unsigned command: " (pr-str (:type cmd-data)))))
                              [network dbid] (cond
                                               (= :new-ledger cmd-type)
                                               (cond


### PR DESCRIPTION
This also includes a fix for the broken new-ledger command - it was checking for a keyword and we were supplying a string.

This is a fix for `maintenance/v1`, we may also need to apply these changes to main, but I haven't checked yet.