### PR TITLE
restore main docker tag

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Run CI Tests & Linters
-    runs-on: [self-hosted, docker]
+    runs-on: [ self-hosted, docker ]
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
@@ -36,7 +36,7 @@ jobs:
   # All of this Docker stuff copied from:
   # https://github.com/marketplace/actions/build-and-push-docker-images#complete-workflow
   docker:
-    runs-on: [self-hosted, docker]
+    runs-on: [ self-hosted, docker ]
     needs: test
     steps:
       - uses: actions/checkout@v2
@@ -45,32 +45,40 @@ jobs:
         run: |
           DOCKER_IMAGE=fluree/ledger
           VERSION=none
-          #if [[ "${{ github.event_name }}" == "schedule" ]]; then
-          #  VERSION=nightly
           if [[ $GITHUB_REF =~ ^refs/tags/v[[:digit:]]+ ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/main ]]; then
             VERSION=main
+          
+          # Uncomment to tag every branch
           #elif [[ $GITHUB_REF == refs/heads/* ]]; then
           #  VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          
+          # Uncomment to tag every pr with pr-[num]
           #elif [[ $GITHUB_REF == refs/pull/* ]]; then
           #  VERSION=pr-${{ github.event.number }}
           fi
+          
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          # Swap comments below to allow alpha, beta, rc versions to be tagged "latest"
-          #if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(-(alpha|beta|rc)[0-9]{1,3})?$ ]]; then
+          
+          # Tag with major version, minor version, and 'latest'
           if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             MINOR=${VERSION%.*}
             MAJOR=${MINOR%.*}
             TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-            # Tag with alpha, beta, rc if found in version string
-            if [[ -n ${BASH_REMATCH[2]} ]]; then TAGS="${TAGS},${DOCKER_IMAGE}:${BASH_REMATCH[2]}"; fi
           fi
+          
+          # Tag with alpha, beta, or rc if present
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}-(alpha|beta|rc)[0-9]{1,3}$ ]]; then
+            TAGS="${TAGS},${DOCKER_IMAGE}:${BASH_REMATCH[1]}"
+          fi
+          
           #if [[ "${{ github.event_name }}" == "push" ]]; then
           #  TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           #fi
+          
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,8 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/v}
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/main ]]; then
+            VERSION=main
           #elif [[ $GITHUB_REF == refs/heads/* ]]; then
           #  VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           #elif [[ $GITHUB_REF == refs/pull/* ]]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,8 +57,9 @@ jobs:
           #  VERSION=pr-${{ github.event.number }}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          # TODO: After 1.0 is released, stop allowing alpha, beta, rc versions to be tagged "latest"
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(-(alpha|beta|rc)[0-9]{1,3})?$ ]]; then
+          # Swap comments below to allow alpha, beta, rc versions to be tagged "latest"
+          #if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(-(alpha|beta|rc)[0-9]{1,3})?$ ]]; then
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             MINOR=${VERSION%.*}
             MAJOR=${MINOR%.*}
             TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"


### PR DESCRIPTION
@bplatz asked if we could bring this back, but only for the main branch. So hopefully this won't clutter up our Docker tags too badly.

I also implemented a post-1.0.0 TODO I noticed in here.