### PR TITLE
Fix single cardinality tempids

### DIFF
--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -234,6 +234,7 @@
 (defn resolve-object
   "Resolves object into its final state so can be used for consistent comparisons with existing data."
   [object _id pred-info tx-state]
+  (log/debug "Resolving object:" object "for pred:" pred-info)
   (let [multi? (pred-info :multi)]
     (if (nil? object)
       (async/go :delete)                                    ;; delete any existing object
@@ -255,6 +256,7 @@
   Performs some logic to determine if the new flake should get added at
   all (i.e. if retract-flake is identical to the new flake)."
   [flakes ^Flake new-flake ^Flake retract-flake pred-info tx-state]
+  (log/debug "add-singleton-flake new-flake:" new-flake "retract-flake:" retract-flake)
   (cond
     ;; no retraction flake, always add
     (nil? retract-flake)
@@ -366,8 +368,10 @@
                   ;; for a retraction flake, if present
                   :else
                   (let [new-flake     (flake/->Flake _id** pid obj* t true nil)
+                        _             (log/debug "new-flake:" (pr-str new-flake))
                         ;; need to see if an existing flake exists that needs to get retracted
                         retract-flake (first (<? (tx-retract/flake _id** pid nil tx-state)))
+                        _             (log/debug "retract-flake:" (pr-str retract-flake))
                         final-flakes  (add-singleton-flake (:_final-flakes acc) new-flake retract-flake pred-info tx-state)]
                     (recur (assoc acc :_final-flakes final-flakes) r)))))))
         (async/close! res-chan))

--- a/src/fluree/db/ledger/transact/core.clj
+++ b/src/fluree/db/ledger/transact/core.clj
@@ -288,7 +288,8 @@
                    need to look up and retract any existing flakes with same subject+predicate
   - _temp-multi-flakes - multi-flakes that need permanent ids yet, but then act like _multi-flakes"
   [{:keys [db-before t tempids upserts] :as tx-state}
-   {:keys [_id _action _meta] :as txi} res-chan]
+   {:keys [_id _action _meta] :as txi}
+   res-chan]
   (async/go
     (try
       (let [_p-o-pairs (dissoc txi :_id :_action :_meta)

--- a/src/fluree/db/ledger/transact/tempid.clj
+++ b/src/fluree/db/ledger/transact/tempid.clj
@@ -110,7 +110,7 @@
              ecount*      ecount]
         (if (nil? tempid)                                   ;; finished
           (do (reset! tempids tempids-map*)
-              (when-not (empty? upserts*)
+              (when (seq upserts*)
                 (reset! upserts upserts*))
               ;; return tx-state, don't need to update ecount in db-after, as dbproto/-with will update it
               tx-state)

--- a/test/fluree/db/ledger/docs/transact/transactions.clj
+++ b/test/fluree/db/ledger/docs/transact/transactions.clj
@@ -19,14 +19,27 @@
   []
   (:conn test/system))
 
+(defn cleanup-data
+  [identifiers]
+  (let [txn  (map (fn [identifier]
+                    {:_id identifier :_action "delete"})
+                  identifiers)
+        resp (<!! (fdb/transact-async (get-conn)
+                                      test/ledger-query+transact
+                                      txn))]
+    (if (= 200 (:status resp))
+      resp
+      (throw (ex-info "Cleaning up data failed"
+                      {:identifiers identifiers
+                       :response    resp})))))
 
 ;; Add collections
 
 (deftest add-collections*
   (testing "Add the person collection")
-  (let [collection-txn  [{:_id "_collection"
+  (let [collection-txn  [{:_id  "_collection"
                           :name "person"}]
-        collection-resp  (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact collection-txn))]
+        collection-resp (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact collection-txn))]
 
     (is (= 200 (:status collection-resp)))
     (is (= 2 (:block collection-resp)))
@@ -36,21 +49,21 @@
 
 (deftest add-predicates
   (testing "Add predicates for the chat app")
-  (let [predicate-txn   [{:_id "_predicate"
-                          :name "person/handle"
-                          :type "string"
+  (let [predicate-txn   [{:_id    "_predicate"
+                          :name   "person/handle"
+                          :type   "string"
                           :unique true}
-                         {:_id "_predicate"
+                         {:_id  "_predicate"
                           :name "person/fullName"
                           :type "string"}
-                         {:_id "_predicate"
-                          :name "person/user"
-                          :type "ref"
+                         {:_id                "_predicate"
+                          :name               "person/user"
+                          :type               "ref"
                           :restrictCollection "_user"}
-                         {:_id "_predicate"
+                         {:_id  "_predicate"
                           :name "person/age"
                           :type "int"}]
-        collection-resp  (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact predicate-txn))]
+        collection-resp (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact predicate-txn))]
 
     (is (= 200 (:status collection-resp)))
     (is (= 3 (:block collection-resp)))
@@ -59,44 +72,44 @@
 (deftest transact-with-temp-ids
   (testing "Issue basic transactions with temporary ids")
   (let [predicate-txn   [{:_id "_user$lEliasz", :username "lEliasz", :auth ["_auth$temp", "_auth$other"]}
-                         {:_id "person",
-                          :handle "lEliasz",
+                         {:_id      "person",
+                          :handle   "lEliasz",
                           :fullName "Louis Eliasz",
-                          :user "_user$lEliasz"}
+                          :user     "_user$lEliasz"}
                          {:_id "_auth$temp", :id "tempAuthRecord"}
                          {:_id "_auth$other", :id "otherAuthRecord"}]
-        collection-resp  (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact predicate-txn))]
+        collection-resp (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact predicate-txn))]
 
     (is (= 200 (:status collection-resp)))
     (is (-> collection-resp :tempids (get "_user$lEliasz")))))
 
 (deftest nested-transaction
   (testing "Issue a transaction with nested data rather than tempID reference")
-  (let [predicate-txn [{:_id "person",
-                        :handle "ajohnson",
-                        :fullName "Andrew Johnson"
-                        :user
-                        {:_id "_user", :username "ajohnson"}}]
+  (let [predicate-txn   [{:_id      "person",
+                          :handle   "ajohnson",
+                          :fullName "Andrew Johnson"
+                          :user
+                          {:_id "_user", :username "ajohnson"}}]
 
 
         collection-resp (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact predicate-txn))]
 
-   (is (= 200 (:status collection-resp)))
-   (is (and (-> collection-resp :tempids (get "person")) (-> collection-resp :tempids (get "_user"))))))
+    (is (= 200 (:status collection-resp)))
+    (is (and (-> collection-resp :tempids (get "person")) (-> collection-resp :tempids (get "_user"))))))
 
 
 (deftest update-user
-  (testing "should replace existing user"
+  (testing "should replace existing user w/ new user in same txn"
     (let [pred-txn   [{:_id "_user$wMorgan", :username "wMorgan"}
-                      {:_id "person$wmorgan"
-                       :handle "wmorgan"
+                      {:_id      "person$wmorgan"
+                       :handle   "wmorgan"
                        :fullName "Wes Morgan"
-                       :user "_user$wMorgan"}]
+                       :user     "_user$wMorgan"}]
           resp1      (<!! (fdb/transact-async (get-conn) test/ledger-query+transact
                                               pred-txn))
           _          (assert (= 200 (:status resp1)))
           update-txn [{:_id "_user$other" :username "other"}
-                      {:_id ["person/handle" "wmorgan"]
+                      {:_id  ["person/handle" "wmorgan"]
                        :user "_user$other"}]
           resp2      (<!! (fdb/transact-async (get-conn) test/ledger-query+transact
                                               update-txn))
@@ -109,31 +122,94 @@
                                              {:syncTo (:block resp2)})
                                            qry))]
       (is (= 1 (count qry-resp)))
-      (is (= "other" (-> qry-resp first (get "_user/username")))))))
+      (is (= "other" (-> qry-resp first (get "_user/username"))))
+      (cleanup-data [["person/handle" "wmorgan"]
+                     ["_user/username" "wMorgan"]
+                     ["_user/username" "other"]])))
+  (testing "should replace existing user w/ pre-existing user in two-tuple"
+    (let [pred-txn   [{:_id "_user$wMorgan", :username "wMorgan"}
+                      {:_id "_user$other", :username "other"}
+                      {:_id      "person$wmorgan"
+                       :handle   "wmorgan"
+                       :fullName "Wes Morgan"
+                       :user     "_user$wMorgan"}]
+          resp1      (<!! (fdb/transact-async (get-conn) test/ledger-query+transact
+                                              pred-txn))
+          _          (is (= 200 (:status resp1))
+                         (pr-str resp1))
+          update-txn [{:_id  ["person/handle" "wmorgan"]
+                       :user ["_user/username" "other"]}]
+          resp2      (<!! (fdb/transact-async (get-conn) test/ledger-query+transact
+                                              update-txn))
+          _          (is (= 200 (:status resp2))
+                         (pr-str resp2))
+          qry        {:select {:?user ["*"]}
+                      :where  [["?person" "person/handle" "wmorgan"]
+                               ["?person" "person/user" "?user"]]}
+          qry-resp   (<!! (fdb/query-async (basic/get-db
+                                             test/ledger-query+transact
+                                             {:syncTo (:block resp2)})
+                                           qry))]
+      (is (= 1 (count qry-resp)))
+      (is (= "other" (-> qry-resp first (get "_user/username"))))
+      (cleanup-data [["person/handle" "wmorgan"]
+                     ["_user/username" "wMorgan"]
+                     ["_user/username" "other"]])))
+  (testing "should replace existing user w/ pre-existing user id"
+    (let [pred-txn      [{:_id "_user$wMorgan", :username "wMorgan"}
+                         {:_id "_user$other", :username "other"}
+                         {:_id      "person$wmorgan"
+                          :handle   "wmorgan"
+                          :fullName "Wes Morgan"
+                          :user     "_user$wMorgan"}]
+          resp1         (<!! (fdb/transact-async (get-conn) test/ledger-query+transact
+                                                 pred-txn))
+          other-user-id (get-in resp1 [:tempids "_user$other"])
+          _             (is (= 200 (:status resp1))
+                            (pr-str resp1))
+          update-txn    [{:_id  ["person/handle" "wmorgan"]
+                          :user other-user-id}]
+          resp2         (<!! (fdb/transact-async (get-conn) test/ledger-query+transact
+                                                 update-txn))
+          _             (is (= 200 (:status resp2))
+                            (pr-str resp2))
+          qry           {:select {:?user ["*"]}
+                         :where  [["?person" "person/handle" "wmorgan"]
+                                  ["?person" "person/user" "?user"]]}
+          qry-resp      (<!! (fdb/query-async (basic/get-db
+                                                test/ledger-query+transact
+                                                {:syncTo (:block resp2)})
+                                              qry))]
+      (is (= 1 (count qry-resp)))
+      (is (= "other" (-> qry-resp first (get "_user/username"))))
+      (cleanup-data [["person/handle" "wmorgan"]
+                     ["_user/username" "wMorgan"]
+                     ["_user/username" "other"]]))))
 
 
 (deftest upserting-data
   (testing "Issue a transaction to upsert data instead of creating a new entity")
-  (let [failure-txn   [{:_id "person", :handle "ajohnson", :age 26}]
-        failure-resp  (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact failure-txn))
-        _a            (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact [{:_id ["_predicate/name" "person/handle"], :upsert true}]))
-        _             (Thread/sleep 2000)
-        success-txn   [{:_id "person", :handle "ajohnson", :age 26}]
-        success-resp  (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact success-txn))]
+  (let [failure-txn  [{:_id "person", :handle "ajohnson", :age 26}]
+        failure-resp (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact failure-txn))
+        _a           (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact
+                                                    [{:_id    ["_predicate/name" "person/handle"]
+                                                      :upsert true}]))
+        _            (Thread/sleep 2000)
+        success-txn  [{:_id "person", :handle "ajohnson", :age 26}]
+        success-resp (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact success-txn))]
 
     (is (and (= 200 (:status success-resp)) (not (= 200 (:status failure-resp)))))))
 
 (deftest deleting-data
   (testing "Issue a transaction to delete parts of data and to delete an entire subject")
-  (let [delete-txn        [{:_id ["person/handle" "ajohnson"] :_action "delete"}
-                           {:_id ["person/handle" "wmorgan"] :_action "delete"}
-                           {:_id ["person/handle" "lEliasz"] :fullName nil}
-                           {:_id ["_user/username" "lEliasz"] :auth [["_auth/id" "tempAuthRecord"]] :_action "delete"}]
-        delete-resp       (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact delete-txn))
-        _                 (Thread/sleep 2000)
-        test-query        {:select ["*", {"person/user" ["*", {"_user/auth" ["*"]}]}] :from "person"}
-        test-resp         (async/<!! (fdb/query-async (basic/get-db test/ledger-query+transact) test-query))
-        remaining-person  (some #(when (get % "person/handle") %) test-resp)]
+  (let [delete-txn       [{:_id ["person/handle" "ajohnson"] :_action "delete"}
+                          {:_id ["person/handle" "lEliasz"] :fullName nil}
+                          {:_id ["_user/username" "lEliasz"] :auth [["_auth/id" "tempAuthRecord"]] :_action "delete"}]
+        delete-resp      (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact delete-txn))
+        _                (Thread/sleep 2000)
+        test-query       {:select ["*", {"person/user" ["*", {"_user/auth" ["*"]}]}] :from "person"}
+        test-resp        (async/<!! (fdb/query-async (basic/get-db test/ledger-query+transact) test-query))
+        remaining-person (some #(when (get % "person/handle") %) test-resp)]
 
     (is (= 200 (:status delete-resp)))
     (is (not (some #(= "ajohnson" (get % "person/handle")) test-resp)))
@@ -143,9 +219,9 @@
 
 (deftest expired-transaction
   (testing "Issue an expired transaction, expect a validation error")
-  (let [expired-txn     [{:_id "_user"  :username "Jonah"}]
-        opts            {:expire (- (System/currentTimeMillis) 100)}
-        txn-resp        (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact expired-txn opts))]
+  (let [expired-txn [{:_id "_user" :username "Jonah"}]
+        opts        {:expire (- (System/currentTimeMillis) 100)}
+        txn-resp    (async/<!! (fdb/transact-async (get-conn) test/ledger-query+transact expired-txn opts))]
     (is (instance? ExceptionInfo txn-resp))
     (is (-> txn-resp
             ex-data


### PR DESCRIPTION
As noted in FC-1415, single-cardinality tempids (e.g. commonly seen in ref preds) were not behaving correctly on updates. In analytical query results both the old and new values were being returned.

This appears to have originated with the transaction refactor from PR #40 which was released with v1.0.0-beta11.

The problem seemed to be that no retract flake was being created for the old value in the post-refactor tempid handling logic.

I'm not sure the fix in this PR is the right place / way to fix this, but it does seem to fix it. Let me know if I should do this differently.