### PR TITLE
FC-1419 Fix/limit+order

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:deps     {org.clojure/clojure            {:mvn/version "1.11.1"}
             org.clojure/data.xml           {:mvn/version "0.2.0-alpha6"}
             com.fluree/alphabase           {:mvn/version "3.2.2"}
-            com.fluree/db                  {:mvn/version "2.0.0-alpha3"}
+            com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
+                                            :sha     "b4baa6a5af9709ae1afcdc124f4c89e68b0d567d"}
             com.fluree/raft                {:mvn/version "1.0.0-beta1"}
             com.fluree/crypto              {:mvn/version "0.3.9"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
             org.clojure/data.xml           {:mvn/version "0.2.0-alpha6"}
             com.fluree/alphabase           {:mvn/version "3.2.2"}
             com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                            :sha     "b4baa6a5af9709ae1afcdc124f4c89e68b0d567d"}
+                                            :sha     "d47d05c25bf584c7a5909af124042f3e8c818443"}
             com.fluree/raft                {:mvn/version "1.0.0-beta1"}
             com.fluree/crypto              {:mvn/version "0.3.9"}
 


### PR DESCRIPTION
Add tests for FC-1419, limit must be taken after result sort for simple-subject-crawl queries.