### PR TITLE
Fix missing bootstrap metadata flakes

### DIFF
--- a/src/fluree/db/ledger/bootstrap.clj
+++ b/src/fluree/db/ledger/bootstrap.clj
@@ -268,7 +268,7 @@
                      :sig sig}}})))
 
 
-(defn bootstrap-db ; TODO: Rename bootstrap-ledger
+(defn bootstrap-ledger
   "Bootstraps a new ledger from a signed new-ledger message."
   [{:keys [conn group]} {:keys [cmd sig] :as command}]
   (go-try

--- a/src/fluree/db/ledger/bootstrap.clj
+++ b/src/fluree/db/ledger/bootstrap.clj
@@ -28,7 +28,7 @@
 
 
 (defn predicate->id-map
-  "Returns a map of predicate namex to final predicate ids, i.e {\"_user/username\" 10}"
+  "Returns a map of predicate names to final predicate ids, i.e {\"_user/username\" 10}"
   [bootstrap-txn]
   (->> bootstrap-txn
        (filter #(= "_predicate" (-> % :_id first)))

--- a/src/fluree/db/ledger/txgroup/monitor.clj
+++ b/src/fluree/db/ledger/txgroup/monitor.clj
@@ -389,10 +389,10 @@
             (doseq [[network ledger-id command] initialize-ledgers]
               (log/info "Initializing new ledger:" (str network "/" ledger-id) "-" command)
               (let [db      (try
-                              (<?? (bootstrap/bootstrap-db system command))
+                              (<?? (bootstrap/bootstrap-ledger system command))
                               (catch Exception e
                                 (log/error e "Failed to bootstrap new ledger:" (str network "/" ledger-id))))
-                    _       (log/trace "bootstrap-db returned:" db)
+                    _       (log/trace "bootstrap-ledger returned:" db)
                     session (session/session conn [network ledger-id])]
                 ;; force session close, so next request will cause session to keep in sync
                 (session/close session))))))

--- a/test/fluree/db/ledger/bootstrap_test.clj
+++ b/test/fluree/db/ledger/bootstrap_test.clj
@@ -1,0 +1,29 @@
+(ns fluree.db.ledger.bootstrap-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.ledger.bootstrap :refer :all]
+            [fluree.db.test-helpers :as test]
+            [fluree.db.flake :as flake]))
+
+(use-fixtures :once test/test-system)
+
+(deftest bootstrap-memory-db-test
+  (testing "all block 1 metadata flakes are present"
+    (let [conn           (:conn test/system)
+          ledger         (test/rand-ledger "test/bootstrap")
+          pred->id       (predicate->id-map bootstrap-txn)
+          ;; expected-preds is a set of tuples of predicate-id and the number
+          ;; of flakes w/ that pred that should appear
+          expected-preds (->> #{["_tx/id" 1] ["_tx/nonce" 1] ["_block/number" 1]
+                                ["_block/instant" 1] ["_block/transactions" 2]}
+                              (reduce (fn [acc [pred card]]
+                                        (assoc acc (pred->id pred) card))
+                                      {})
+                              set)
+          actual-preds   (->> (bootstrap-memory-db conn ledger)
+                              :flakes
+                              (reduce (fn [acc flake]
+                                        (update acc (flake/p flake)
+                                                (fnil inc 0)))
+                                      {})
+                              set)]
+      (is (every? actual-preds expected-preds)))))


### PR DESCRIPTION
Fixes FC-1420

Not sure what happened here but I (most likely inadvertently) removed these in b2f9d1a800f16af0e51aa94a5063c6658b3516fb. This adds them back and adds a test to check that they're all there.

This only affects `main` / 2.x.