### PR TITLE
Eliminate unnecessary sleeps in tests

### DIFF
--- a/test/fluree/db/ledger/docs/query/analytical_query.clj
+++ b/test/fluree/db/ledger/docs/query/analytical_query.clj
@@ -9,144 +9,141 @@
 (use-fixtures :once test/test-system-deprecated)
 
 (deftest analytical-with-prefix-two-tuple-subject
-  (testing "Analytical query with prefix, with two-tuple subject")
-  (let [crawl-query      {:select "?nums"
-                          :where [["$fdb", ["person/handle", "zsmith"], "person/favNums", "?nums"]]}
-        db  (basic/get-db test/ledger-chat)
-        res  (async/<!! (fdb/query-async db crawl-query))]
-    (is (= (set res) (set [5 645 28 -1 1223])))))
+  (testing "Analytical query with prefix, with two-tuple subject"
+    (let [crawl-query      {:select "?nums"
+                            :where [["$fdb", ["person/handle", "zsmith"], "person/favNums", "?nums"]]}
+          db  (basic/get-db test/ledger-chat)
+          res  (async/<!! (fdb/query-async db crawl-query))]
+      (is (= (set res) (set [5 645 28 -1 1223]))))))
 
 (deftest analytical-with-two-tuple-subject
-  (testing "Analytical query with two-tuple subject")
-  (let [crawl-query      {:select "?nums"
-                          :where [[["person/handle", "zsmith"], "person/favNums", "?nums"]]}
-        db  (basic/get-db test/ledger-chat)
-        res  (async/<!! (fdb/query-async db crawl-query))]
-    (is (= (set res) (set [5 645 28 -1 1223])))))
+  (testing "Analytical query with two-tuple subject"
+    (let [crawl-query      {:select "?nums"
+                            :where [[["person/handle", "zsmith"], "person/favNums", "?nums"]]}
+          db  (basic/get-db test/ledger-chat)
+          res  (async/<!! (fdb/query-async db crawl-query))]
+      (is (= (set res) (set [5 645 28 -1 1223]))))))
 
 
 (deftest analytical-with-two-clauses
-  (testing "Analytical query with two clauses")
-  (let [crawl-query      {:select "?nums"
-                          :where [["?person", "person/handle", "zsmith"],
-                                   ["?person", "person/favNums", "?nums"]]}
-        db  (basic/get-db test/ledger-chat)
-        res  (async/<!! (fdb/query-async db crawl-query))]
-    (is (= (set res) (set [5 645 28 -1 1223])))))
+  (testing "Analytical query with two clauses"
+    (let [crawl-query      {:select "?nums"
+                            :where [["?person", "person/handle", "zsmith"],
+                                     ["?person", "person/favNums", "?nums"]]}
+          db  (basic/get-db test/ledger-chat)
+          res  (async/<!! (fdb/query-async db crawl-query))]
+      (is (= (set res) (set [5 645 28 -1 1223]))))))
 
 (deftest analytical-with-nil-subject
-  (testing "Analytical query with nil subject")
-  (let [crawl-query      {:select "?nums",
-                          :where [ ["$fdb", nil, "person/favNums", "?nums"] ]}
-        db  (basic/get-db test/ledger-chat)
-        res  (async/<!! (fdb/query-async db crawl-query))]
-    (is (= (set res) (set [7 1223 -2 28 12 9 0 1950 5 645 -1 2 98])))))
+  (testing "Analytical query with nil subject"
+    (let [crawl-query      {:select "?nums",
+                            :where [ ["$fdb", nil, "person/favNums", "?nums"]]}
+          db  (basic/get-db test/ledger-chat)
+          res  (async/<!! (fdb/query-async db crawl-query))]
+      (is (= (set res) (set [7 1223 -2 28 12 9 0 1950 5 645 -1 2 98]))))))
 
 (deftest analytical-with-prefix-two-clauses-two-tuple-subject
-  (testing "Analytical query with two clauses, two bound variables, two-tuple subjects")
-  (let [crawl-query       {:select  ["?nums1", "?nums2"]
-                           :where [[["person/handle", "zsmith"],
-                                    "person/favNums", "?nums1"],
-                                   [["person/handle", "jdoe"],
-                                    "person/favNums", "?nums2"] ]}
-        db  (basic/get-db test/ledger-chat)
-        res  (async/<!! (fdb/query-async db crawl-query))]
-    (is (= (first (map set (apply (partial map vector) res))) #{-1 645 1223 28 5}))
-    (is (= (last (map set (apply (partial map vector) res))) #{0 -2 1223 12 98}))))
+  (testing "Analytical query with two clauses, two bound variables, two-tuple subjects"
+    (let [crawl-query       {:select  ["?nums1", "?nums2"]
+                             :where [[["person/handle", "zsmith"],
+                                      "person/favNums", "?nums1"],
+                                     [["person/handle", "jdoe"],
+                                      "person/favNums", "?nums2"]]}
+          db  (basic/get-db test/ledger-chat)
+          res  (async/<!! (fdb/query-async db crawl-query))]
+      (is (= (first (map set (apply (partial map vector) res))) #{-1 645 1223 28 5}))
+      (is (= (last (map set (apply (partial map vector) res))) #{0 -2 1223 12 98})))))
 
 
 (deftest analytical-with-prefix-two-clauses-two-tuple-subject-matching
-  (testing "Analytical query with two clauses, one bound variable, filtered between two two-tuple subjects")
-  (let [crawl-query      { :select "?nums"
-                          :where [ ["$fdb", ["person/handle", "zsmith"], "person/favNums", "?nums"],
-                                  ["$fdb", ["person/handle", "jdoe"], "person/favNums", "?nums"]]}
-        db  (basic/get-db test/ledger-chat)
-        res  (async/<!! (fdb/query-async db crawl-query))]
-    (is (= res [1223]))))
+  (testing "Analytical query with two clauses, one bound variable, filtered between two two-tuple subjects"
+    (let [crawl-query      { :select "?nums"
+                            :where [ ["$fdb", ["person/handle", "zsmith"], "person/favNums", "?nums"],
+                                    ["$fdb", ["person/handle", "jdoe"], "person/favNums", "?nums"]]}
+          db  (basic/get-db test/ledger-chat)
+          res  (async/<!! (fdb/query-async db crawl-query))]
+      (is (= res [1223])))))
 
 (deftest analytical-select-one-with-aggregate-sum
-  (testing "Analytical query with Select One clause using Aggregate sum operand")
-  (let [crawl-query     {:select "(sum ?nums)",
-                         :where [[["person/handle" "zsmith"] "person/favNums" "?nums"]]}
-        db  (basic/get-db test/ledger-chat)
-        res (async/<!! (fdb/query-async db crawl-query))]
-    (is (= res (reduce + [5 645 28 -1 1223])))))
+  (testing "Analytical query with Select One clause using Aggregate sum operand"
+    (let [crawl-query     {:select "(sum ?nums)",
+                           :where [[["person/handle" "zsmith"] "person/favNums" "?nums"]]}
+          db  (basic/get-db test/ledger-chat)
+          res (async/<!! (fdb/query-async db crawl-query))]
+      (is (= res (reduce + [5 645 28 -1 1223]))))))
 
 ;;TODO - Fix why sample 10 only returning 9
 (deftest analytical-select-one-with-aggregate-sample
-  (testing "Analytical query with Select One clause using Aggregate sample operand")
-  (let [sample-query     {:select "(sample 10 ?nums)",
-                         :where [[nil "person/favNums" "?nums"]]}
-        total-query      {:select "?nums",
-                          :where [[nil "person/favNums" "?nums"]]}
-        db  (basic/get-db test/ledger-chat)
-        sample-res (async/<!! (fdb/query-async db sample-query))
-        total-res (async/<!! (fdb/query-async db total-query))]
-    (is (= 10 (count sample-res)))
-    (is (= (every? #(contains? (set total-res) %) sample-res) true))))
+  (testing "Analytical query with Select One clause using Aggregate sample operand"
+    (let [sample-query     {:select "(sample 10 ?nums)",
+                            :where [[nil "person/favNums" "?nums"]]}
+          total-query      {:select "?nums",
+                            :where [[nil "person/favNums" "?nums"]]}
+          db  (basic/get-db test/ledger-chat)
+          sample-res (async/<!! (fdb/query-async db sample-query))
+          total-res (async/<!! (fdb/query-async db total-query))]
+      (is (= 10 (count sample-res)))
+      (is (= (every? #(contains? (set total-res) %) sample-res) true)))))
 
 (deftest analytical-reverse-crawl-from-bound-variable
-  (testing "Analytical query that reverse-crawls from bound-variable predicate to all subjects with that predicate")
-  (let [crawl-query     {:select {:?artist ["*" {:person/_favArtists ["*"]}]},
-                         :where [[nil "person/favArtists" "?artist"]]}
-        db  (basic/get-db test/ledger-chat)
-        res (async/<!! (fdb/query-async db crawl-query))]
-    (is (vector? res))
-    (is (contains? (first res) :_id))
-    (is (contains? (first res) "artist/name"))
-    (is (contains? (first res) "person/_favArtists"))
-    (is (vector? (get (first res) "person/_favArtists")))))
+  (testing "Analytical query that reverse-crawls from bound-variable predicate to all subjects with that predicate"
+    (let [crawl-query     {:select {:?artist ["*" {:person/_favArtists ["*"]}]},
+                           :where [[nil "person/favArtists" "?artist"]]}
+          db  (basic/get-db test/ledger-chat)
+          res (async/<!! (fdb/query-async db crawl-query))]
+      (is (vector? res))
+      (is (contains? (first res) :_id))
+      (is (contains? (first res) "artist/name"))
+      (is (contains? (first res) "person/_favArtists"))
+      (is (vector? (get (first res) "person/_favArtists"))))))
 
 
 (deftest analytical-where-clause-filter-option
-  (testing "Analytical query Filter option in Where clause")
-  (let [analytical-query     {:select {:?person ["person/handle" "person/favNums"]},
-                              :where
-                                      [["$fdb"
-                                        "?person"
-                                        "person/favNums"
-                                        "(> ?nums 1000)"]]}
+  (testing "Analytical query Filter option in Where clause"
+    (let [analytical-query     {:select {:?person ["person/handle" "person/favNums"]},
+                                :where
+                                        [["$fdb"
+                                          "?person"
+                                          "person/favNums"
+                                          "(> ?nums 1000)"]]}
 
-        db  (basic/get-db test/ledger-chat)
-        res (async/<!! (fdb/query-async db analytical-query))]
+          db  (basic/get-db test/ledger-chat)
+          res (async/<!! (fdb/query-async db analytical-query))]
 
-    (is (not (contains? (set (map #(get (first %) "person/handle") res)) "anguyen")))
-    ;because ["person/handle", "anguyen"] only has nums < 1000
+      (is (not (contains? (set (map #(get (first %) "person/handle") res)) "anguyen")))
+      ;because ["person/handle", "anguyen"] only has nums < 1000
 
-    (is (every? number? (get (first (first res)) "person/favNums")))))
+      (is (every? number? (get (first (first res)) "person/favNums"))))))
 
 ;TODO: build out similar tests for other filter operators
 
 (deftest analytical-across-sources-db-blocks
-  (Thread/sleep 5000)
-  (testing "Analytical query in which Where clause queries across db blocks")
-  (let [analytical-query     {:select "?nums",
-                              :where
-                                      [["$fdb4" ["person/handle" "zsmith"] "person/favNums" "?nums"]
-                                       ["$fdb4" ["person/handle" "jdoe"] "person/favNums" "?nums"]]}
+  (testing "Analytical query in which Where clause queries across db blocks"
+    (let [analytical-query     {:select "?nums",
+                                :where [["$fdb4" ["person/handle" "zsmith"] "person/favNums" "?nums"]
+                                        ["$fdb4" ["person/handle" "jdoe"] "person/favNums" "?nums"]]}
 
 
-        db  (basic/get-db test/ledger-chat)
-        res (async/<!! (fdb/query-async db analytical-query))]
+          db  (basic/get-db test/ledger-chat)
+          res (async/<!! (fdb/query-async db analytical-query))]
 
-    (is (every? number? res))))
+      (is (every? number? res)))))
 
-(deftest analytical-across-sources-wikidata
-  (testing "Analytical query in which Where clause queries across sources that include wikidata")
-  (let [analytical-query     {:select ["?name" "?artist" "?artwork" "?artworkLabel"],
-                              :where
-                                      [[["person/handle" "jdoe"] "person/favArtists" "?artist"]
-                                       ["?artist" "artist/name" "?name"]
-                                       ["$wd" "?artwork" "wdt:P170" "?creator"]
-                                       ["$wd" "?creator" "?label" "?name"]]}
+(deftest ^:online analytical-across-sources-wikidata
+  (testing "Analytical query in which Where clause queries across sources that include wikidata"
+    (let [analytical-query     {:select ["?name" "?artist" "?artwork" "?artworkLabel"],
+                                :where [[["person/handle" "jdoe"] "person/favArtists" "?artist"]
+                                        ["?artist" "artist/name" "?name"]
+                                        ["$wd" "?artwork" "wdt:P170" "?creator"]
+                                        ["$wd" "?creator" "?label" "?name"]]}
 
 
-        db  (basic/get-db test/ledger-chat)
-        res (async/<!! (fdb/query-async db analytical-query))]
+          db  (basic/get-db test/ledger-chat)
+          res (async/<!! (fdb/query-async db analytical-query))]
 
-    (log/info "WIKIDATA: " res)
-    ;TODO: FINISH TEST!!!
-    ))
+      (log/info "WIKIDATA: " res))))
+      ;TODO: FINISH TEST!!!
+
 
 
 (deftest analytical-query-test
@@ -160,9 +157,9 @@
   ;(analytical-select-one-with-aggregate-sample)
   (analytical-reverse-crawl-from-bound-variable)
   (analytical-where-clause-filter-option)
-  (analytical-across-sources-db-blocks)
+  (analytical-across-sources-db-blocks))
   ;(analytical-across-sources-wikidata)
-  )
+
 
 (deftest tests-independent
   (basic/add-collections*)
@@ -174,12 +171,8 @@
 
 (comment
 
-
-
-
-
   { :selectOne "(sum ?nums)"
-   :where [[["person/handle", "zsmith"], "person/favNums", "?nums"]] }
+   :where [[["person/handle", "zsmith"], "person/favNums", "?nums"]]}
 
   { :selectOne "(sample 10 ?nums)",
    :where [[nil, "person/favNums", "?nums"]]}
@@ -190,17 +183,17 @@
   ; tx first
 
   [{ :_id ["person/handle", "zsmith"]
-    :favNums [100] }]
+    :favNums [100]}]
 
   ; then query
   { :select "?nums"
-   :where [ ["$fdb4", ["person/handle", "zsmith"], "person/favNums", "?nums"], ["$fdb5", ["person/handle", "zsmith"], "person/favNums", "?nums"] ] }
+   :where [ ["$fdb4", ["person/handle", "zsmith"], "person/favNums", "?nums"], ["$fdb5", ["person/handle", "zsmith"], "person/favNums", "?nums"]]}
 
   { :select  ["?name", "?artist", "?artwork", "?artworkLabel"],
    :where [[["person/handle", "jdoe"], "person/favArtists", "?artist"],
                      ["?artist", "artist/name", "?name"],
                      ["$wd", "?artwork", "wdt:P170", "?creator"],
-                     ["$wd", "?creator", "?label", "?name"]] }
+                     ["$wd", "?creator", "?label", "?name"]]}
 
 
   { :select ["?handle", "?title", "?narrative_location"],
@@ -215,7 +208,5 @@
    :where [[["person/handle", "jdoe"], "person/favArtists", "?artist"],
            ["?artist", "artist/name", "?name"],
            ["$wd", "?artwork", "wdt:P170", "?creator", {"limit" 5, "distinct" false}],
-           ["$wd", "?creator", "?label", "?name"]]}
+           ["$wd", "?creator", "?label", "?name"]]})
 
-
-  )

--- a/test/fluree/db/ledger/indexing/full_text_test.clj
+++ b/test/fluree/db/ledger/indexing/full_text_test.clj
@@ -21,11 +21,11 @@
 
 (deftest ^:integration full-text-search-test
   (testing "Full Text Search"
-    (let [ledger (test/rand-ledger test/ledger-chat)]
+    (let [ledger (test/rand-ledger test/ledger-chat)
+          _ (test/transact-schema ledger "chat.edn")
+          _ (test/transact-schema ledger "chat-preds.edn")
+          chat-txn (test/transact-data ledger "chat.edn")]
       (testing "with full text predicates and data"
-        (test/transact-schema ledger "chat.edn")
-        (test/transact-schema ledger "chat-preds.edn")
-        (test/transact-data ledger "chat.edn")
         (Thread/sleep 500) ; Allow the full text indexer to incorporate the
                            ; block in a separate thread.
         (testing "query"
@@ -33,7 +33,7 @@
                    :where [["?p" "fullText:person/fullName" "Doe"]]}
                 subject @(-> test/system
                              :conn
-                             (fdb/db ledger)
+                             (fdb/db ledger {:syncTo (:block chat-txn)})
                              (fdb/query q))]
             (is (= (count subject)
                    1)


### PR DESCRIPTION
Closes FC-1245

There only ended up being one place where we were sleeping instead of using `:syncTo`, but I eliminated some other unnecessary sleeps in the tests. It's a few seconds faster overall now. :)