### PR TITLE
Allow setting the fluree.db log level w/ an env var

### DIFF
--- a/resources/fluree_start.sh
+++ b/resources/fluree_start.sh
@@ -170,11 +170,14 @@ if [ "$1" == "test" ]; then
   exit 0
 fi
 
-FDB_LOG_LEVEL=${FDB_LOG_LEVEL:-INFO}
+FLUREE_DB_LOG_LEVEL=${FLUREE_DB_LOG_LEVEL:-INFO}
+FLUREE_RAFT_LOG_LEVEL=${FLUREE_RAFT_LOG_LEVEL:-INFO}
 
 echo "Fluree ledger starting with properties file: ${FLUREE_PROPERTIES}"
 echo "Fluree ledger starting with java options: ${XMS} ${XMX} ${JAVA_OPTS}"
-echo "fluree.db log level is ${FDB_LOG_LEVEL}"
+echo "fluree.db log level is ${FLUREE_DB_LOG_LEVEL}"
+echo "fluree.raft log level is ${FLUREE_RAFT_LOG_LEVEL}"
 
 exec ${JAVA_X} -server ${XMX} ${XMS} ${JAVA_OPTS} ${FLUREE_ARGS} -Dfdb.properties.file=${FLUREE_PROPERTIES} \
-  -Dfdb.log.ansi -Dfdb.log.level=${FDB_LOG_LEVEL} -Dlogback.configurationFile=${FLUREE_LOGBACK_CONFIGURATION_FILE} -jar ${FLUREE_SERVER}
+  -Dfdb.log.ansi -Dfluree.db.log.level=${FLUREE_DB_LOG_LEVEL} -Dfluree.raft.log.level=${FLUREE_RAFT_LOG_LEVEL} \
+  -Dlogback.configurationFile=${FLUREE_LOGBACK_CONFIGURATION_FILE} -jar ${FLUREE_SERVER}

--- a/resources/fluree_start.sh
+++ b/resources/fluree_start.sh
@@ -170,8 +170,11 @@ if [ "$1" == "test" ]; then
   exit 0
 fi
 
+FDB_LOG_LEVEL=${FDB_LOG_LEVEL:-INFO}
+
 echo "Fluree ledger starting with properties file: ${FLUREE_PROPERTIES}"
 echo "Fluree ledger starting with java options: ${XMS} ${XMX} ${JAVA_OPTS}"
+echo "fluree.db log level is ${FDB_LOG_LEVEL}"
 
 exec ${JAVA_X} -server ${XMX} ${XMS} ${JAVA_OPTS} ${FLUREE_ARGS} -Dfdb.properties.file=${FLUREE_PROPERTIES} \
-  -Dfdb.log.ansi -Dlogback.configurationFile=${FLUREE_LOGBACK_CONFIGURATION_FILE} -jar ${FLUREE_SERVER}
+  -Dfdb.log.ansi -Dfdb.log.level=${FDB_LOG_LEVEL} -Dlogback.configurationFile=${FLUREE_LOGBACK_CONFIGURATION_FILE} -jar ${FLUREE_SERVER}

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -29,7 +29,8 @@
     </root>
 
     <logger name="ch.qos.logback" level="WARN"/>
-    <logger name="fluree.db" level="${fdb.log.level}"/>
+    <logger name="fluree.db" level="${fluree.db.log.level}"/>
+    <logger name="fluree.raft" level="${fluree.raft.log.level}"/>
 
 </configuration>
 

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -29,7 +29,7 @@
     </root>
 
     <logger name="ch.qos.logback" level="WARN"/>
-    <!-- <logger name="fluree.db" level="DEBUG"/> -->
+    <logger name="fluree.db" level="${fdb.log.level}"/>
 
 </configuration>
 


### PR DESCRIPTION
Setting the env var `FLUREE_DB_LOG_LEVEL=DEBUG` and/or `FLUREE_RAFT_LOG_LEVEL=DEBUG` will now get you debug logs for all fluree.db.* or fluree.raft.* namespaces, respectively. Defaults to `INFO`.