### PR TITLE
FC-814: feature/command pool

### DIFF
--- a/src/fluree/db/ledger/consensus/none.clj
+++ b/src/fluree/db/ledger/consensus/none.clj
@@ -102,6 +102,12 @@
 
                    :assoc-in (update-state/assoc-in* entry state-atom)
 
+                   :put-pool (let [[_ pool-path cmd-id cmd] entry]
+                               (-> state-atom
+                                   (swap! update-state/put-pool pool-path cmd-id cmd)
+                                   (update-state/get-pool pool-path cmd-id)
+                                   (= cmd)))
+
                    ;; For no consensus, just returns true
                    :worker-assign true
 

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -9,6 +9,7 @@
             [fluree.db.storage.core :as storage]
             [fluree.db.serde.avro :as avro]
             [fluree.db.event-bus :as event-bus]
+            [fluree.db.flake :as flake]
             [fluree.db.ledger.consensus.tcp :as ftcp]
             [fluree.db.util.async :refer [go-try <? <??]]
             [fluree.db.ledger.txgroup.txgroup-proto :as txproto :refer [TxGroup]]
@@ -18,8 +19,7 @@
             [fluree.crypto :as crypto]
             [fluree.db.ledger.storage :as ledger-storage]
             [fluree.db.constants :as const]
-            [fluree.db.util.core :as util :refer [exception?]])
-  (:import (fluree.db.flake Flake)))
+            [fluree.db.util.core :as util :refer [exception?]]))
 
 (set! *warn-on-reflection* true)
 
@@ -779,9 +779,9 @@
                       ;; would error in raft if these are not included, recreate from block data
                       block-data* (assoc block-data :cmd-types #{:tx}
                                                     :txns (->> (:flakes block-data)
-                                                               (keep #(let [^Flake f %]
-                                                                        (when (= const/$_tx:id (.-p f))
-                                                                          [(.-o f) nil])))
+                                                               (keep (fn [f]
+                                                                       (when (= const/$_tx:id (flake/p f))
+                                                                         [(flake/o f) nil])))
                                                                (into {})))]
 
                   (log/info (str "Ledger " network "/" ledger-id

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -347,6 +347,12 @@
 
                    :assoc-in (update-state/assoc-in* command state-atom)
 
+                   :put-pool (let [[_ pool-path cmd-id cmd] command]
+                               (-> state-atom
+                                   (swap! update-state/put-pool pool-path cmd-id cmd)
+                                   (update-state/get-pool pool-path cmd-id)
+                                   (= cmd)))
+
                    ;; worker assignments are a little different in that they organize the key-seq
                    ;; both prepended by the server-id (for easy lookup of work based on server-id)
                    ;; and also at the end of the key-seq (for easy lookup of worker(s) for given resource(s))

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -269,7 +269,7 @@
 
 
 (defn state-machine
-  [_ state-atom storage-read storage-write]
+  [_ state-atom storage-read storage-write pool-size]
   (fn [command _]
     (let [op     (first command)
           result (case op
@@ -522,7 +522,9 @@
   (let [{:keys [port this-server log-directory entries-max log-history
                 storage-ledger-read storage-group-read storage-ledger-write
                 storage-group-write storage-group-exists storage-group-delete
-                storage-group-list private-keys open-api]} raft-config
+                storage-group-list private-keys open-api pool-size]}
+        raft-config
+
         event-chan             (async/chan)
         command-chan           (async/chan)
         state-machine-atom     (atom default-state)
@@ -544,7 +546,8 @@
                                  :state-machine (state-machine this-server
                                                                state-machine-atom
                                                                storage-ledger-read
-                                                               storage-ledger-write)
+                                                               storage-ledger-write
+                                                               pool-size)
                                  :snapshot-write (snapshot-writer snapshot-config)
                                  :snapshot-reify (snapshot-reify snapshot-config)
                                  :snapshot-xfer (snapshot-xfer snapshot-config)

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -347,11 +347,11 @@
 
                    :assoc-in (update-state/assoc-in* command state-atom)
 
+                   ;; returns a boolean for whether the command was added
                    :put-pool (let [[_ pool-path cmd-id cmd] command]
                                (-> state-atom
-                                   (swap! update-state/put-pool pool-path cmd-id cmd)
-                                   (update-state/get-pool pool-path cmd-id)
-                                   (= cmd)))
+                                   (swap! update-state/put-pool pool-size pool-path cmd-id cmd)
+                                   (update-state/in-pool? pool-path cmd-id cmd)))
 
                    ;; worker assignments are a little different in that they organize the key-seq
                    ;; both prepended by the server-id (for easy lookup of work based on server-id)

--- a/src/fluree/db/ledger/consensus/raft.clj
+++ b/src/fluree/db/ledger/consensus/raft.clj
@@ -19,8 +19,7 @@
             [fluree.db.ledger.storage :as ledger-storage]
             [fluree.db.constants :as const]
             [fluree.db.util.core :as util :refer [exception?]])
-  (:import (java.util UUID)
-           (fluree.db.flake Flake)))
+  (:import (fluree.db.flake Flake)))
 
 (set! *warn-on-reflection* true)
 
@@ -448,7 +447,7 @@
   connection doesn't exist (not established, or closed)."
   [raft server operation data callback]
   (let [this-server (:this-server raft)
-        msg-id      (str (UUID/randomUUID))
+        msg-id      (str (random-uuid))
         header      {:op     operation
                      :from   this-server
                      :to     server
@@ -619,7 +618,7 @@
                  leader (<! (leader-async group))]
              (if (= (:this-server raft') leader)
                (raft/new-entry raft' entry callback timeout-ms)
-               (let [id           (str (UUID/randomUUID))
+               (let [id           (str (random-uuid))
                      command-data {:id id :entry entry}]
                  ;; since not leader, register entry id locally and will receive callback when committed to state machine
                  (raft/register-callback raft' id timeout-ms callback)
@@ -642,7 +641,7 @@
   ([group newServer timeout-ms callback]
    (go-try (let [raft'  (:raft group)
                  leader (<! (leader-async group))
-                 id     (str (UUID/randomUUID))]
+                 id     (str (random-uuid))]
              (if (= (:this-server raft') leader)
                (let [command-chan (-> group :command-chan)]
                  (async/put! command-chan [:add-server [id newServer] callback]))
@@ -666,7 +665,7 @@
   ([group server timeout-ms callback]
    (go-try (let [raft'  (:raft group)
                  leader (<! (leader-async group))
-                 id     (str (UUID/randomUUID))]
+                 id     (str (random-uuid))]
              (if (= (:this-server raft') leader)
                (let [command-chan (-> group :command-chan)]
                  (async/put! command-chan [:remove-server [id server] callback]))
@@ -894,7 +893,7 @@
            (<? (initialize-leader group conn)))
 
          ;; monitor state changes to kick of transactions for any queues
-         (register-state-change-fn (str (UUID/randomUUID))
+         (register-state-change-fn (str (random-uuid))
                                    (partial group-monitor/state-updates-monitor system))
 
          ;; in case we are responsible for networks but some exist in current queue, kick them off

--- a/src/fluree/db/ledger/consensus/update_state.clj
+++ b/src/fluree/db/ledger/consensus/update_state.clj
@@ -10,8 +10,6 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:const max-pool-size 100000)
-
 (defn get-pool
   "Returns the entry from the capped pool in the `state` map specified by
   `pool-path` with key `k`. Returns the entire pool if `k` is not provided."
@@ -24,13 +22,15 @@
   "Adds `v` to a capped command pool map within the `state` map specified by
   `pool-path` under the key `k` if and only if there are less than
   `max-pool-size` entries previously in the specified pool."
-  [state pool-path k v]
+  [state max-size pool-path k v]
   (update-in state pool-path (fn [pool]
-                               (if (< (count pool) max-pool-size)
+                               (if (< (count pool) max-size)
                                  (assoc pool k v)
                                  pool))))
 
 (defn in-pool?
+  "Returns a boolean indicating whether or not the key `k` has the value `v`
+  within the command pool in the `state` map under the `pool-path`."
   [state pool-path k v]
   (-> state
       (get-pool pool-path k)

--- a/src/fluree/db/ledger/consensus/update_state.clj
+++ b/src/fluree/db/ledger/consensus/update_state.clj
@@ -30,6 +30,12 @@
                                  (assoc pool k v)
                                  pool))))
 
+(defn in-pool?
+  [state pool-path k v]
+  (-> state
+      (get-pool pool-path k)
+      (= v)))
+
 (defn dissoc-ks
   "Dissoc, but with a key sequence."
   [map ks]

--- a/src/fluree/db/ledger/consensus/update_state.clj
+++ b/src/fluree/db/ledger/consensus/update_state.clj
@@ -10,6 +10,26 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:const max-pool-size 100000)
+
+(defn get-pool
+  "Returns the entry from the capped pool in the `state` map specified by
+  `pool-path` with key `k`. Returns the entire pool if `k` is not provided."
+  ([state pool-path]
+   (get-in state pool-path))
+  ([state pool-path k]
+   (get-in state (conj pool-path k))))
+
+(defn put-pool
+  "Adds `v` to a capped command pool map within the `state` map specified by
+  `pool-path` under the key `k` if and only if there are less than
+  `max-pool-size` entries previously in the specified pool."
+  [state pool-path k v]
+  (update-in state pool-path (fn [pool]
+                               (if (< (count pool) max-pool-size)
+                                 (assoc pool k v)
+                                 pool))))
+
 (defn dissoc-ks
   "Dissoc, but with a key sequence."
   [map ks]
@@ -244,4 +264,3 @@
                        " Submission server: " submission-server
                        " Assigned network server: " (get-in @state-atom [:_work :networks network])))
         false))))
-

--- a/src/fluree/db/ledger/txgroup/core.clj
+++ b/src/fluree/db/ledger/txgroup/core.clj
@@ -74,26 +74,19 @@
                 log-history snapshot-threshold log-directory storage-type
                 storage-ledger-read storage-group-read storage-ledger-write
                 storage-group-write storage-group-exists storage-group-delete
-                storage-group-list catch-up-rounds private-keys
-                open-api]} group-settings
-        raft-config {:port                  port
-                     :log-directory         log-directory
-                     :storage-ledger-read   storage-ledger-read
-                     :storage-ledger-write  storage-ledger-write
-                     :storage-group-read    storage-group-read
-                     :storage-group-write   storage-group-write
-                     :storage-group-exists  storage-group-exists
-                     :storage-group-delete  storage-group-delete
-                     :storage-group-list    storage-group-list
-                     :timeout-ms            timeout-ms
-                     :heartbeat-ms          heartbeat-ms
-                     :log-history           log-history
-                     :snapshot-threshold    snapshot-threshold
-                     :only-leader-snapshots (not= :file storage-type)
-                     :join?                 join?
-                     :catch-up-rounds       catch-up-rounds
-                     :private-keys          private-keys
-                     :open-api              open-api}
+                storage-group-list catch-up-rounds private-keys open-api
+                pending-tx-limit]}
+        group-settings
+
+        raft-config (-> group-settings
+                        (select-keys [:port :log-directory :storage-ledger-read
+                                      :storage-ledger-write :storage-group-read
+                                      :storage-group-write :storage-group-exists
+                                      :storage-group-delete :storage-group-list
+                                      :timeout-ms :heartbeat-ms :log-history
+                                      :snapshot-threshold :join? :catch-up-rounds
+                                      :private-keys :open-api :pool-size])
+                        (assoc :only-leader-snapshots (not= :file storage-type)))
         group       (condp = consensus-type
                       :raft (raft/launch-raft-server
                               server-configs
@@ -113,4 +106,3 @@
   [group version]
   (assert (number? version))
   (txproto/kv-assoc-in group [:version] version))
-

--- a/src/fluree/db/ledger/txgroup/monitor.clj
+++ b/src/fluree/db/ledger/txgroup/monitor.clj
@@ -178,15 +178,15 @@
 
 
 (defn queued-tx
-  "If state change is a new tx that was queued
-   returns three-tuple of [network ledger-id txid], else nil."
+  "If state change is a new command that was queued returns three-tuple
+  of [network ledger-id command-id], else nil."
   [state-change]
   (let [{:keys [command result]} state-change
-        [op arg1 arg2] command]
-    (when (and (= :assoc-in op)
+        [op arg1 arg2 arg3] command]
+    (when (and (= :put-pool op)
                (= :cmd-queue (first arg1))
                (true? result))
-      (let [{:keys [ledger-id network id]} arg2]
+      (let [{:keys [ledger-id network id]} arg3]
         [network ledger-id id]))))
 
 
@@ -404,7 +404,7 @@
                 session (session/session conn [(get command 2) (get command 3)])]
             (session/close session))))
 
-      :assoc-in
+      :put-pool
       (when-let [[network ledger-id _] (queued-tx state-change)]
         (when (network-assigned-to? (:group conn) network)
           (let [queue-chan (ledger-queue conn network ledger-id)]

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -67,10 +67,10 @@
   (async/<!! (kv-dissoc-in-async group ks)))
 
 (defn kv-max-in-async
-  "Writes value to specified key sequence. Will only write is proposed value is
-  greater than the current value. Returns true if value is written, false if it
-  is not written. Returns core async channel that will eventually have a
-  response."
+  "Writes value to specified key sequence. Will only write if the proposed value
+  is greater than the current value. Returns a core async channel that will
+  eventually have a response of true if the value is written, false if it is not
+  written."
   [group ks v]
   (assert (number? v))
   (let [command [:max-in ks v]]
@@ -325,7 +325,7 @@
            (command-queue group network))))
 
 (defn queue-command-async
-  "Enqueues a new command processing"
+  "Enqueues a new command or transaction for processing."
   [group network ledger-id command-id command]
   (let [queue-time  (System/currentTimeMillis)
         size        (-> command :cmd count)

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -87,6 +87,14 @@
    (let [command [:cas-in ks swap-v compare-ks compare-v]]
      (-new-entry-async raft command))))
 
+(defn kv-put-pool-async
+  [group pool-path k v]
+  (let [command [:put-pool pool-path k v]]
+    (-new-entry-async group command)))
+
+(defn kv-put-pool
+  [group pool-path k v]
+  (async/<!! (kv-put-pool-async group pool-path k v)))
 
 ;; version, this-server commands
 
@@ -327,7 +335,7 @@
                      :network   network
                      :ledger-id ledger-id
                      :instant   queue-time}]
-    (kv-assoc-in-async group [:cmd-queue network command-id] queue-entry)))
+    (kv-put-pool-async group [:cmd-queue network] command-id queue-entry)))
 
 ;; Block commands
 

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -325,7 +325,7 @@
            (command-queue group network))))
 
 (defn queue-command-async
-  "Enqueues a new command or transaction for processing."
+  "Adds a new command to the command queue for processing."
   [group network ledger-id command-id command]
   (let [queue-time  (System/currentTimeMillis)
         size        (-> command :cmd count)

--- a/src/fluree/db/ledger/txgroup/txgroup_proto.clj
+++ b/src/fluree/db/ledger/txgroup/txgroup_proto.clj
@@ -319,14 +319,15 @@
 (defn queue-command-async
   "Enqueues a new command processing"
   [group network ledger-id command-id command]
-  (kv-assoc-in-async group [:cmd-queue network command-id]
-                     {:command command
-                      :size    (count (:cmd command))
-                      :id      command-id
-                      :network network
-                      :ledger-id    ledger-id
-                      :instant (System/currentTimeMillis)}))
-
+  (let [queue-time  (System/currentTimeMillis)
+        size        (-> command :cmd count)
+        queue-entry {:command   command
+                     :size      size
+                     :id        command-id
+                     :network   network
+                     :ledger-id ledger-id
+                     :instant   queue-time}]
+    (kv-assoc-in-async group [:cmd-queue network command-id] queue-entry)))
 
 ;; Block commands
 

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -39,15 +39,10 @@
             [fluree.db.query.fql-resp :refer [flakes->res]])
   (:import (java.time Instant)
            (java.net BindException URL)
-           (fluree.db.flake Flake)
            (clojure.lang ExceptionInfo)
            (org.httpkit BytesInputStream)))
 
 (set! *warn-on-reflection* true)
-
-(defn s
-  [^Flake f]
-  (.-s f))
 
 (defn- count-graphql-resp
   [res fuel]
@@ -380,7 +375,7 @@
               flakes'      (concat flakes-all flakes)]
           (if (empty? txs)
             (let [_                 (session/close session)
-                  flakes-by-subject (group-by s flakes')
+                  flakes-by-subject (group-by flake/s flakes')
                   res-map           (async/go-loop [vals' (vals flakes-by-subject)
                                                     acc []]
                                       (let [val' (first vals')
@@ -1037,4 +1032,3 @@
                        (server-close-fn :timeout 1000))
                      (swap! web-server dissoc port))]
       (map->WebServer {:close close-fn}))))
-

--- a/src/fluree/db/peer/websocket.clj
+++ b/src/fluree/db/peer/websocket.clj
@@ -6,8 +6,7 @@
             [fluree.db.permissions-validate :as permissions-validate]
             [fluree.db.peer.messages :as messages]
             [fluree.db.api :as fdb]
-            [fluree.db.ledger.util :as util])
-  (:import (java.util UUID)))
+            [fluree.db.ledger.util :as util]))
 
 (set! *warn-on-reflection* true)
 
@@ -118,7 +117,7 @@
 
 (defn handler
   [system req]
-  (let [ws-id (str (UUID/randomUUID))
+  (let [ws-id (str (random-uuid))
         producer-chan (async/chan (async/sliding-buffer 20))
         consumer-chan (async/chan (async/sliding-buffer 20))
         msg-handler #(future
@@ -148,4 +147,3 @@
         {:status  400
          :headers {"content-type" "application/text"}
          :body    "Expected a websocket request"}))))
-

--- a/src/fluree/db/server_settings.clj
+++ b/src/fluree/db/server_settings.clj
@@ -60,6 +60,7 @@
    :fdb-memory-reindex           "1mb"
    :fdb-memory-reindex-max       "2mb"
    :fdb-stats-report-frequency   "1m"
+   :fdb-pending-tx-limit         "10000"
 
    ;; api settings
    :fdb-api-port                 8090                       ;; integer
@@ -624,6 +625,7 @@
      :catch-up-rounds       (env-integer (:fdb-group-catch-up-rounds settings)) ;; defaults to 10
      :log-history           (env-integer (:fdb-group-log-history settings)) ;; number of historical log files to keep around
      :snapshot-threshold    (env-integer (:fdb-group-snapshot-threshold settings)) ;; how many new index entries before creating a new snapshot
+     :pool-size             (env-integer (:fdb-pending-tx-limit settings)) ;; maximum number of pending commands allowed at one time
      :private-keys          (not-empty private-keys)        ;; Transactor group private key(s). Separate multiple keys with commas. These keys will be replicated to all servers in the group, which they can use as identities for external networks or as defaults for DBs. They only need to be provided one time.
      :open-api              (-> settings :fdb-api-open env-boolean)
      :log-directory         (-> settings :fdb-group-log-directory canonicalize-path) ;; where to store raft logs for the group

--- a/test/fluree/db/ledger/consensus/update_state_test.clj
+++ b/test/fluree/db/ledger/consensus/update_state_test.clj
@@ -1,0 +1,17 @@
+(ns fluree.db.ledger.consensus.update-state-test
+  (:require [clojure.test :refer :all]
+            [fluree.db.ledger.consensus.update-state :as update-state]))
+
+(deftest pool-test
+  (testing "Capped state pools"
+    (let [state     {}
+          pool-path [:foo :bar]]
+      (testing "with added data"
+        (let [k         :baz
+              k'        :nope
+              v         :bip
+              new-state (update-state/put-pool state 10 pool-path k v)]
+          (is (update-state/in-pool? new-state pool-path k v)
+              "contains the added data")
+          (is (not (update-state/in-pool? new-state pool-path k' v))
+                  "does not contain additional data"))))))

--- a/test/fluree/db/ledger/consensus/update_state_test.clj
+++ b/test/fluree/db/ledger/consensus/update_state_test.clj
@@ -6,12 +6,21 @@
   (testing "Capped state pools"
     (let [state     {}
           pool-path [:foo :bar]]
-      (testing "with added data"
+      (testing "when empty"
+        (let [k :baz
+              v :bip]
+          (is (not (update-state/in-pool? state pool-path k v))
+              "does not contain any data")))
+      (testing "after adding data"
         (let [k         :baz
-              k'        :nope
               v         :bip
               new-state (update-state/put-pool state 10 pool-path k v)]
           (is (update-state/in-pool? new-state pool-path k v)
-              "contains the added data")
-          (is (not (update-state/in-pool? new-state pool-path k' v))
-                  "does not contain additional data"))))))
+              "contains that data")
+          (testing "when at capacity"
+            (let [limit 1
+                  k'          :bop
+                  v'          :bap
+                  newer-state (update-state/put-pool new-state limit pool-path k' v')]
+              (is (not (update-state/in-pool? newer-state pool-path k' v'))
+                  "does not add more data"))))))))


### PR DESCRIPTION
This patch adds a new `:put-pool` state machine transition that adds entries to a capped command pool in state. The cap is configurable under the `:fdb-pending-tx-limit` property/environment variable and the default is now 10,000, which is probably pretty high, but I don't have a good picture of what a typical workflow is like. The pool is capped for each individual ledger (network and ledger-id pair), but we can change it if capping on the network or globally is more appropriate. If a new transaction comes in when the command pool is full, the system will throw an exception with a 503 status back to the client, and the client controls when/if to retry.

In an attempt to keep pull requests manageable, I've decided to implement FC-814 in phases, and this is phase 1: adding the command pool and throwing an exception when trying to add to a full pool. Phase 2 will implement backpressure where, instead of throwing exceptions, the server directs connected clients to pause when there's a full queue, and detects when the queue has been drained and tells those clients to continue sending messages. Phase 3 will refactor the other state transitions to use pure functions to both update state, and respond to those state updates so the state management code can be simpler, more modular, and, most importantly, testable. 