### PR TITLE
Support :json pred parsing & add tests for it

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
             ;com.fluree/db                  {:mvn/version "2.0.0-alpha6"}
             ;com.fluree/db                  {:local/root "../db"}
             com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                            :sha "df4982804a507aa0832ecddf95fe4ab0d5b511ea"}
+                                            :sha "62adc19356234d2d7dc68e8d2a1a8240ed7a4cdc"}
             com.fluree/raft                {:mvn/version "1.0.0-beta1"}
             com.fluree/crypto              {:mvn/version "0.4.0"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
             ;com.fluree/db                  {:mvn/version "2.0.0-alpha6"}
             ;com.fluree/db                  {:local/root "../db"}
             com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                            :sha "31ecb0c4f94993c947a2b8cfd10715a6e8b53a46"}
+                                            :sha "35f051ac2ea03752a1fafc68321300b680934234"}
             com.fluree/raft                {:mvn/version "1.0.0-beta1"}
             com.fluree/crypto              {:mvn/version "0.4.0"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
             ;com.fluree/db                  {:mvn/version "2.0.0-alpha6"}
             ;com.fluree/db                  {:local/root "../db"}
             com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                            :sha "35f051ac2ea03752a1fafc68321300b680934234"}
+                                            :sha "df4982804a507aa0832ecddf95fe4ab0d5b511ea"}
             com.fluree/raft                {:mvn/version "1.0.0-beta1"}
             com.fluree/crypto              {:mvn/version "0.4.0"}
 

--- a/dev-resources/data/json-preds.edn
+++ b/dev-resources/data/json-preds.edn
@@ -1,0 +1,6 @@
+[{:_id      "_user"
+  :username "aj"
+  :json     {"foo" "bar"}
+  :friend   {:_id      "_user"
+             :username "ajFriend"
+             :json     {"bizz" "buzz"}}}]

--- a/dev-resources/schemas/json-preds.edn
+++ b/dev-resources/schemas/json-preds.edn
@@ -1,0 +1,7 @@
+[{:_id  "_predicate"
+  :name "_user/json"
+  :type "json"}
+ {:_id                "_predicate"
+  :name               "_user/friend"
+  :type               "ref"
+  :restrictCollection "_user"}]

--- a/src/fluree/db/peer/http_api.clj
+++ b/src/fluree/db/peer/http_api.clj
@@ -385,9 +385,9 @@
                                                     acc []]
                                       (let [val' (first vals')
                                             res  (<? (flakes->res db-after
-                                                                      (volatile! {})
-                                                                      (volatile! fuel-tot)
-                                                                      1000000 {:wildcard? true, :select {}} val'))
+                                                                  (volatile! {})
+                                                                  (volatile! fuel-tot)
+                                                                  1000000 {:wildcard? true, :select {}} {} val'))
                                             acc' (conj acc res)]
                                         (if (not-empty (rest vals'))
                                           (recur (rest vals') acc')

--- a/test/fluree/db/ledger/api/open_test.clj
+++ b/test/fluree/db/ledger/api/open_test.clj
@@ -3,7 +3,6 @@
             [fluree.db.test-helpers :as test]
             [org.httpkit.client :as http]
             [fluree.db.util.json :as json]
-            [byte-streams :as bs]
             [fluree.db.api :as fdb]
             [fluree.db.query.http-signatures :as http-signatures])
   (:import (java.util UUID)))

--- a/test/fluree/db/ledger/predicate/json_test.clj
+++ b/test/fluree/db/ledger/predicate/json_test.clj
@@ -1,0 +1,109 @@
+(ns fluree.db.ledger.predicate.json-test
+  (:require [clojure.test :refer :all]
+            [clojure.core.async :refer [<!!]]
+            [fluree.db.test-helpers :as test]
+            [fluree.db.api :as fdb]
+            [fluree.db.util.json :as json]
+            [org.httpkit.client :as http]))
+
+(use-fixtures :once test/test-system)
+
+(deftest transact-json-test
+  (let [ledger (test/rand-ledger "pred/json")
+        _ (test/assert-success
+            (test/transact-schema ledger "json-preds"))
+        api-url (str "http://localhost:" @test/port "/fdb/" ledger "/")]
+    (testing "valid JSON succeeds"
+      (let [txn "[{\"_id\": \"_user\", \"_user/username\": \"tester\", \"_user/json\": {\"foo\": \"bar\"}}]"
+            {:keys [status body]} @(http/post (str api-url "transact")
+                                              {:headers {"Content-Type" "application/json"}
+                                               :body    txn})]
+        (is (= 200 status))
+        (is (some #(-> % (nth 2) (= "{\"foo\":\"bar\"}")) (-> body json/parse :flakes)))))
+    (testing "invalid JSON fails"
+      (let [txn "[{\"_id\": \"_user\", \"_user/username\": \"tester\", \"_user/json\": {\"foo\": \"bar\"}]" ; missing closing }
+            {:keys [status]} @(http/post (str api-url "transact")
+                                         {:headers {"Content-Type" "application/json"}
+                                          :body    txn})]
+        ;; This should really return a 4xx error, but it's a 5xx error as of the date I wrote this test.
+        ;; So I'm just checking that this is in the "error range" of HTTP status codes.
+        (is (< 399 status))))))
+
+(deftest query-json-test
+  (let [ledger (test/rand-ledger "pred/json")
+        _      (test/assert-success
+                 (test/transact-schema ledger "json-preds"))
+        {:keys [block]} (test/assert-success
+                          (test/transact-data ledger "json-preds"))
+        db     (fdb/db (:conn test/system) ledger {:syncTo block})]
+
+    (testing "returns JSON string by default"
+      (let [query {:select ["*"]
+                   :from   "_user"}
+            res   (<!! (fdb/query-async db query))]
+        (is (every? string? (map #(get % "_user/json") res)))
+        (let [parsed (map #(-> % (get "_user/json") json/parse) res)]
+          (is (every? #{{:foo "bar"} {:bizz "buzz"}} parsed)))))
+
+    (testing "basic query from collection returns parsed JSON when requested"
+      (let [query {:select ["*"]
+                   :from   "_user"
+                   :opts   {:parseJSON true}}
+            res   (<!! (fdb/query-async db query))]
+        (is (= {:foo "bar"} (-> res
+                                (->> (some #(when (= "aj" (get % "_user/username")) %)))
+                                (get "_user/json"))))
+        (is (= {:bizz "buzz"} (-> res
+                                  (->> (some #(when (= "ajFriend" (get % "_user/username")) %)))
+                                  (get "_user/json"))))))
+
+    (testing "analytical query from collection rdf:type returns parsed JSON when requested"
+      (let [query {:select {"?s" ["*"]}
+                   :where  [["?s", "rdf:type", "_user"]]
+                   :opts   {:parseJSON true}}
+            res   (<!! (fdb/query-async db query))]
+        (is (= {:foo "bar"} (-> res
+                                (->> (some #(when (= "aj" (get % "_user/username")) %)))
+                                (get "_user/json"))))
+        (is (= {:bizz "buzz"} (-> res
+                                  (->> (some #(when (= "ajFriend" (get % "_user/username")) %)))
+                                  (get "_user/json"))))))
+
+    (testing "basic query from two-tuple returns parsed JSON when requested"
+      (let [query {:select ["*" {:friend ["*"]}]
+                   :from   ["_user/username", "aj"],
+                   :opts   {:parseJSON true}}
+            res   (<!! (fdb/query-async db query))]
+        (is (= {:foo "bar"} (-> res first (get "_user/json")))
+            (str "Unexpected query result: " (pr-str res)))
+        (is (= {:bizz "buzz"} (-> res first (get-in ["friend" "_user/json"])))
+            (str "Unexpected query result: " (pr-str res)))))
+
+    (testing "basic query from subject _id returns parsed JSON when requested"
+      (let [query {:select ["*" {:friend ["*"]}]
+                   :from 87960930223081
+                   :opts {:parseJSON true}}
+            res (<!! (fdb/query-async db query))]
+        (is (= {:foo "bar"} (-> res first (get "_user/json")))
+            (str "Unexpected query result:" (pr-str res)))
+        (is (= {:bizz "buzz"} (-> res first (get-in ["friend" "_user/json"])))
+            (str "Unexpected query result:" (pr-str res)))))
+
+    (testing "analytical query from triples returns parsed JSON when requested"
+      (let [query {:select {"?s" ["*"]}
+                   :where [["?s" "_user/username" "?o"]]
+                   :opts {:parseJSON true}}
+            res (<!! (fdb/query-async db query))]
+        (is (= {:foo "bar"} (-> res first (get "_user/json")))
+            (str "Unexpected query result: " (pr-str res)))
+        (is (= {:bizz "buzz"} (-> res second (get "_user/json")))
+            (str "Unexpected query result: " (pr-str res)))))
+
+    (testing "basic query with graph crawl returns parsed JSON when requested"
+      (let [query {:select ["*" {:friend ["*"]}]
+                   :from   "_user"
+                   :opts {:parseJSON true}}
+            res (<!! (fdb/query-async db query))]
+        (is (= {:bizz "buzz"} (-> res first (get "_user/json"))))
+        (is (= {:foo "bar"} (-> res second (get "_user/json"))))
+        (is (= {:bizz "buzz"} (-> res second (get-in ["friend" "_user/json"]))))))))

--- a/test/fluree/db/ledger/rule_functions_test.clj
+++ b/test/fluree/db/ledger/rule_functions_test.clj
@@ -7,25 +7,15 @@
 (use-fixtures :once (partial test/test-system
                              {:fdb-api-open false}))
 
-(defn assert-success
-  [result]
-  (if (instance? Throwable result)
-    (throw result)
-    result))
-
-(defn printlnn
-  [& s]
-  (apply println (concat s ["\n"])))
-
 (deftest update-role-fn-test
   (testing "Updating a role fn takes effect right away"
     (let [jdoe-keys          (test/load-keys "jdoe-auth")
           zsmith-keys        (test/load-keys "zsmith-auth")
           ledger             (test/rand-ledger "test/role-fn-update")
-          _                  (assert-success (test/transact-schema ledger "chat.edn" :clj))
-          _                  (assert-success (test/transact-schema ledger "chat-preds.edn" :clj))
-          _                  (assert-success (test/transact-data ledger "chat.edn" :clj))
-          {:keys [block]} (assert-success (test/transact-data ledger "chat-rules.edn" :clj))
+          _                  (test/assert-success (test/transact-schema ledger "chat.edn" :clj))
+          _                  (test/assert-success (test/transact-schema ledger "chat-preds.edn" :clj))
+          _                  (test/assert-success (test/transact-data ledger "chat.edn" :clj))
+          {:keys [block]} (test/assert-success (test/transact-data ledger "chat-rules.edn" :clj))
 
           db                 (fdb/db (:conn test/system) ledger {:syncTo block})
 
@@ -37,7 +27,7 @@
           own-chat-id        (-> own-chats first :_id)
           edit-own-chat-txn  [{:_id          own-chat-id
                                :chat/message "Now it's this other thing"}]
-          {:keys [block]} (assert-success
+          {:keys [block]} (test/assert-success
                             (<!! (fdb/transact-async (:conn test/system)
                                                      ledger edit-own-chat-txn
                                                      {:private-key (:private jdoe-keys)})))
@@ -66,7 +56,7 @@
           chat-edit-rule-txn [{:_id ["_rule/id" "editOwnChats"]
                                :fns [{:_id "_fn"
                                       :code "false"}]}]
-          chat-edit-rule-resp (assert-success
+          chat-edit-rule-resp (test/assert-success
                                 (<!! (fdb/transact-async (:conn test/system)
                                                          ledger chat-edit-rule-txn)))
           jdoe-edits-own-chat-txn [{:_id own-chat-id
@@ -78,7 +68,7 @@
           ;; doesn't work; see above
           ;zsmith-edits-chat-txn [{:_id others-chat-id
           ;                        :chat/message "I edited my message!"}]
-          ;zsmith-edits-chat-resp (assert-success
+          ;zsmith-edits-chat-resp (test/assert-success
           ;                         (<!! (fdb/transact-async (:conn test/system)
           ;                                                  ledger zsmith-edits-chat-txn
           ;                                                  {:private-key (:private zsmith-keys)})))]

--- a/test/fluree/db/test_helpers.clj
+++ b/test/fluree/db/test_helpers.clj
@@ -190,7 +190,8 @@
   closed-api mode since this doesn't sign the HTTP requests."
   ([type ledger file] (transact-resource type ledger file :http))
   ([type ledger file api]
-   (let [tx (->> file (str (name type) "/") io/resource slurp edn/read-string)]
+   (let [filename (if (str/ends-with? file ".edn") file (str file ".edn"))
+         tx (->> filename (str (name type) "/") io/resource slurp edn/read-string)]
      (case api
        :clj
        @(fdb/transact (:conn system) ledger tx)
@@ -341,6 +342,19 @@
       dir-path
       (throw (ex-info "Failed to create temp directory"
                       {:dir-path dir-path})))))
+
+
+(defn assert-success
+  [result]
+  (if (instance? Throwable result)
+    (throw result)
+    result))
+
+
+(defn printlnn
+  [& s]
+  (apply println (concat s ["\n"])))
+
 
 ;; ======================== DEPRECATED ===============================
 


### PR DESCRIPTION
This goes with https://github.com/fluree/db/pull/203 to add a `:parseJSON true` opt for queries w/ predicates of type `:json`. This also adds some tests for `:json` preds in transactions and queries.