### PR TITLE
Feature: -Xmx for commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM clojure:temurin-11-tools-deps-1.11.1.1165-bullseye-slim AS builder
+FROM --platform=$BUILDPLATFORM clojure:temurin-11-tools-deps-1.11.1.1257-bullseye-slim AS builder
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends curl
 


### PR DESCRIPTION
Modifies the startup script to allow setting -Xmx (etc.) for commands too. `:reindex` sometimes needs this on large datasets, for example.

Snuck in a Docker builder base image version bump too. :)