### PR TITLE
Feature/index rebuild from last

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
          org.clojure/data.xml           {:mvn/version "0.2.0-alpha8"}
          com.fluree/alphabase           {:mvn/version "3.3.0"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "bbd33250e826bf51259c1a954dc00d1324fa4819"}
+                                         :sha     "add56b63e276f55200f4e21d074531dbccc66765"}
          com.fluree/raft                {:mvn/version "1.0.0-beta1"}
          com.fluree/crypto              {:mvn/version "0.4.0"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/data.xml           {:mvn/version "0.2.0-alpha8"}
          com.fluree/alphabase           {:mvn/version "3.3.0"}
-         com.fluree/db                  {:mvn/version "1.0.5"}
+         com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
+                                         :sha     "bbd33250e826bf51259c1a954dc00d1324fa4819"}
          com.fluree/raft                {:mvn/version "1.0.0-beta1"}
          com.fluree/crypto              {:mvn/version "0.4.0"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -39,7 +39,7 @@
  :aliases
  {:mvn/group-id    com.fluree
   :mvn/artifact-id ledger
-  :mvn/version     "1.0.5"
+  :mvn/version     "1.0.5-SNAPSHOT"
 
   :dev
   {:extra-paths ["dev", "test"]

--- a/dev/remote_debug/README.md
+++ b/dev/remote_debug/README.md
@@ -1,0 +1,10 @@
+# Working with remote socket REPL
+Optionally, Fluree can be started with a Remote REPL socket open for debugging purpose.
+
+The ./fluree_start.sh script has an option that automatically enables this feature.
+
+When starting with ./fluree.start.sh, simply add the option:
+```bash
+./fluree_start.sh -repl-port=5555
+```
+This will start Fluree with a remote REPL socket open on port 5555.

--- a/src/data_readers.cljc
+++ b/src/data_readers.cljc
@@ -1,0 +1,3 @@
+{Flake fluree.db.flake/parts->Flake
+ FdbIndexConfig fluree.db.index/map->IndexConfig
+ FlureeUnresolvedNode fluree.db.storage.core/map->UnresolvedNode}

--- a/src/fluree/db/ledger/consensus/dbsync2.clj
+++ b/src/fluree/db/ledger/consensus/dbsync2.clj
@@ -436,10 +436,11 @@
 
 (defn consistency-full-check
   [conn ledgers-info remote-sync-servers]
-  (let [sync-chan     (async/chan)                          ;; files to sync are placed on this channel
-        res-chan      (async/chan)                          ;; results file sync (error/success) are placed on this channel
-        parallelism   8]
-    (if (empty? ledgers-info)
+  (let [sync-chan   (async/chan) ;; files to sync are placed on this channel
+        res-chan    (async/chan) ;; results file sync (error/success) are placed on this channel
+        parallelism 8]
+    (if (or (empty? ledgers-info)
+            (empty? remote-sync-servers))
       (go ::done)
       (let [remote-copy-fn (remote-copy-fn* conn remote-sync-servers 3000)]
         (check-all-ledgers-consistency conn ledgers-info sync-chan)

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -142,7 +142,8 @@
            node-bytes      (flake/size-bytes resolved-flakes)
            overflow?       (overflow? node-bytes)
            underflow?      (and (underflow? node-bytes) (not= 1 (count old-children)))
-           history         (<? history-ch)]
+           history         (or (<? history-ch) ;; with predicates with no-history turned on, this can be empty
+                               #{})]
        (cond
          overflow?
          (let [splits     (split-flakes resolved-flakes node-bytes)

--- a/src/fluree/db/ledger/indexing.clj
+++ b/src/fluree/db/ledger/indexing.clj
@@ -105,6 +105,23 @@
                 :else
                 (recur (inc n) his*)))))))
 
+(defn throw-write-leaf-condition
+  "In the case there is a leaf write exception, dump out as much data as possible to help diagnose.
+
+  condition-str is overflow, underflow or standard"
+  [e condition-str network dbid block t idx-type base-id leaf-i flakes history
+   old-children new-children resolved overflow-data underflow-data]
+  (log/error e "Error creating leaf index segment from"
+             condition-str ".\n Data: "
+             (pr-str {:network        network :dbid dbid :block block :t t
+                      :idx-type       idx-type :base-id base-id :leaf-i leaf-i
+                      :flakes         flakes :history history
+                      :old-children   old-children :new-children new-children
+                      :resolved       resolved
+                      :overflow-data  overflow-data
+                      :underflow-data underflow-data}))
+  (throw e))
+
 
 (defn index-leaf
   "Given a node, idx-novelty, returns [ [nodes] skip n].
@@ -139,8 +156,16 @@
                                      (first flakes))
                    base-id         (str (util/random-uuid))
                    his-split       (get-history-in-range history first-flake rhs' comparator)
-                   id              (<? (storage/write-leaf conn network dbid idx-type base-id
-                                                           flakes his-split))
+                   id              (async/<! (storage/write-leaf conn network dbid idx-type base-id
+                                                                 flakes his-split))
+                   _               (when (util/exception? id)
+                                     (throw-write-leaf-condition
+                                       id "OVERFLOW"
+                                       network dbid block t idx-type base-id leaf-i
+                                       flakes history
+                                       old-children new-children resolved
+                                       {:his-split his-split :first-flake first-flake :rhs' rhs' :splits splits}
+                                       nil))
                    child-leftmost? (and leftmost? (zero? split-i))
                    child-node      (storage/map->UnresolvedNode
                                      {:conn      conn :config config
@@ -182,8 +207,18 @@
                current-node-his (get-history-in-range history fflake rhs comparator)
                his-in-range     (into current-node-his combine-his)
                flakes           (into (:flakes resolved) (:flakes combine-leaf))
-               id               (<? (storage/write-leaf conn network dbid idx-type base-id
-                                                        flakes his-in-range))
+               id               (async/<! (storage/write-leaf conn network dbid idx-type base-id
+                                                              flakes his-in-range))
+               _                (when (util/exception? id)
+                                  (throw-write-leaf-condition
+                                    id "UNDERFLOW"
+                                    network dbid block t idx-type base-id leaf-i
+                                    flakes history
+                                    old-children new-children resolved
+                                    nil
+                                    {:skip          skip :n n :combine-leaf combine-leaf
+                                     :combine-bytes combine-bytes
+                                     :combine-his   combine-his}))
                size             (+ node-bytes combine-bytes)
                ;; current node might be empty, so we need to get first and rhs from node, NOT resolved
                [first-flake rhs] (if (= skip :previous)
@@ -204,8 +239,15 @@
          :else
          (let [base-id    (str (util/random-uuid))
                flakes     (:flakes resolved)
-               id         (<? (storage/write-leaf conn network dbid idx-type base-id
-                                                  flakes history))
+               id         (async/<! (storage/write-leaf conn network dbid idx-type base-id
+                                                        flakes history))
+               _          (when (util/exception? id)
+                            (throw-write-leaf-condition
+                              id "STANDARD"
+                              network dbid block t idx-type base-id leaf-i
+                              flakes history
+                              old-children new-children resolved
+                              nil nil))
                child-node (storage/map->UnresolvedNode
                             {:conn      conn :config config
                              :dbid      dbid :id id :leaf true
@@ -266,14 +308,14 @@
            child-n    (count children)
            at-leaf?   (:leaf (val (first children)))
            children*  (loop [child-i   (dec child-n)
-                             rhs       rhs
+                             rhs*       rhs
                              children* (empty children)]
                         (if (< child-i 0) ;; at end of result set
                           children*
                           (let [child         (val (nth children child-i))
                                 child-rhs     (:rhs child)
-                                _             (when-not (or (= (dec child-i) child-n) (= child-rhs rhs))
-                                                (throw (ex-info (str "Something went wrong. Child-rhs does not equal rhs: " {:child-rhs child-rhs :rhs rhs})
+                                _             (when-not (or (= (dec child-i) child-n) (= child-rhs rhs*))
+                                                (throw (ex-info (str "Something went wrong. Child-rhs does not equal rhs: " {:child-rhs child-rhs :rhs rhs*})
                                                                 {:status 500
                                                                  :error  :db/unexpected-error})))
                                 child-first   (:first child)
@@ -289,7 +331,21 @@
                                 dirty?        (or (seq novelty) (seq remove-preds?))
                                 [new-nodes skip n] (if dirty?
                                                      (if at-leaf?
-                                                       (<? (index-leaf conn network dbid child block t idx-novelty child-rhs children children* child-i remove-preds?))
+                                                       (let [res (async/<! (index-leaf conn network dbid child block t idx-novelty child-rhs children children* child-i remove-preds?))]
+                                                         (if (util/exception? res)
+                                                           (do
+                                                             (log/error "Error indexing leaf from index-branch. Branch Data:\n"
+                                                                        (pr-str {:base-id base-id :idx-type idx-type :child-n child-n :rhs rhs
+                                                                                  :resolved resolved})
+                                                                        "\nChild Data:\n:"
+                                                                        (pr-str {:child-i child-i :rhs* rhs*
+                                                                                 :child-first child-first :child-rhs child-rhs
+                                                                                 :leftmost? (:leftmost? child)
+                                                                                 :novelty novelty})
+                                                                        "\nIDX Novelty:\n:"
+                                                                        (pr-str idx-novelty))
+                                                             (throw res))
+                                                           res))
                                                        [(<? (index-branch conn network dbid child idx-novelty block t child-rhs progress remove-preds?)) nil nil])
                                                      [[child] nil nil])
                                 new-rhs       (:first (first new-nodes))

--- a/src/fluree/db/server.clj
+++ b/src/fluree/db/server.clj
@@ -27,6 +27,8 @@
 
 (set! *warn-on-reflection* true)
 
+(def system nil)
+
 ;; instantiates server operations
 
 (defn local-message-process
@@ -205,6 +207,7 @@
   (if-let [command (:fdb-command environ/env)]
     (execute-command command)
     (let [system (startup)]
+      (alter-var-root #'system (constantly system))
       (.addShutdownHook
         (Runtime/getRuntime)
         (Thread. ^Runnable


### PR DESCRIPTION
Fix for v1.x branch.

This addresses an indexing issue where serialzation of an index leaf's history will throw an exception because the `:flakes` value is `nil`.

This situation only happens if an index leaf is full of predicates dedicated with no history, in which case there will not be any history flakes on that node. The fix will ensure an empty vector is at least present on the history leaf in that situation.

This also adds an immense amount of logging for index serialization issues. Because there can be 10s of thousands of index nodes, an error without context of where it happened is not useful. If this sort of error happens again, which it shouldn't, a ton of information will be logged out that could allow diagnosis of the problem.

This also adds a remote REPL option to ./fluree_start.sh to assist in remote debugging if needed.
